### PR TITLE
Simplify query pipeline 

### DIFF
--- a/resources/clj-kondo.exports/com.github.camsaul/toucan2/config.edn
+++ b/resources/clj-kondo.exports/com.github.camsaul/toucan2/config.edn
@@ -8,7 +8,6 @@
   toucan2.core/with-model             clojure.core/let
   toucan2.model/with-model            clojure.core/let
   toucan2.query/with-built-query      clojure.core/let
-  toucan2.query/with-resolved-query   clojure.core/let
   toucan2.tools.compile/build         clojure.core/identity
   toucan2.tools.compile/compile       clojure.core/identity}
 
@@ -37,4 +36,5 @@
    toucan2.tools.before-delete/define-before-delete macros.toucan2.tools.helpers/define-before-delete
    toucan2.tools.before-insert/define-before-insert macros.toucan2.tools.before-insert/define-before-insert
    toucan2.tools.before-select/define-before-select macros.toucan2.tools.helpers/define-before-select
-   toucan2.tools.before-update/define-before-update macros.toucan2.tools.before-update/define-before-update}}}
+   toucan2.tools.before-update/define-before-update macros.toucan2.tools.before-update/define-before-update
+   toucan2.tools.named-query/define-named-query     macros.toucan2.tools.named-query/define-named-query}}}

--- a/resources/clj-kondo.exports/com.github.camsaul/toucan2/macros/toucan2/tools/named_query.clj
+++ b/resources/clj-kondo.exports/com.github.camsaul/toucan2/macros/toucan2/tools/named_query.clj
@@ -1,0 +1,21 @@
+(ns macros.toucan2.tools.named-query)
+
+;;; separate function because recursive macroexpansion doesn't seem to work.
+(defn- define-named-query*
+  [query-name query-type model resolved-query]
+  `(do
+     ~query-name
+     ~query-type
+     ~model
+     (fn [~(vary-meta '&query-type assoc :clj-kondo/ignore [:unused-binding])
+          ~(vary-meta '&model assoc :clj-kondo/ignore [:unused-binding])
+          ~(vary-meta '&parsed-args assoc :clj-kondo/ignore [:unused-binding])
+          ~(vary-meta '&unresolved-query assoc :clj-kondo/ignore [:unused-binding])]
+       ~resolved-query)))
+
+(defmacro define-named-query
+  ([query-name resolved-query]
+   (define-named-query* query-name :default :default resolved-query))
+
+  ([query-name query-type model resolved-query]
+   (define-named-query* query-name query-type model resolved-query)))

--- a/scripts/lint-and-test-fast.sh
+++ b/scripts/lint-and-test-fast.sh
@@ -1,0 +1,9 @@
+#! /usr/bin/env bash
+
+# This script is a convenience for running linters and tests without having to type in a bunch of nonsense.
+
+set -euxo pipefail
+
+clj-kondo --parallel --lint src test toucan1/src/ toucan1/test/
+
+clojure -X:dev:test:test-h2

--- a/src/toucan2/delete.clj
+++ b/src/toucan2/delete.clj
@@ -23,4 +23,4 @@
   "Returns number of rows deleted."
   {:arglists '([modelable & conditions? query?])}
   [& unparsed-args]
-  (pipeline/transduce-unparsed :toucan.query-type/delete.update-count unparsed-args))
+  (pipeline/transduce-unparsed-with-default-rf :toucan.query-type/delete.update-count unparsed-args))

--- a/src/toucan2/delete.clj
+++ b/src/toucan2/delete.clj
@@ -5,14 +5,13 @@
    [toucan2.pipeline :as pipeline]
    [toucan2.query :as query]))
 
-(m/defmethod query/build [#_query-type :toucan.query-type/delete.*
-                          #_model      :default
-                          #_query      clojure.lang.IPersistentMap]
-  [query-type model parsed-args]
-  (let [parsed-args (update parsed-args :query (fn [query]
-                                                 (merge {:delete-from (query/honeysql-table-and-alias model)}
-                                                        query)))]
-    (next-method query-type model parsed-args)))
+(m/defmethod pipeline/transduce-resolved-query [#_query-type :toucan.query-type/delete.*
+                                                #_model      :default
+                                                #_query      clojure.lang.IPersistentMap]
+  [rf query-type model parsed-args resolved-query]
+  (let [resolved-query (merge {:delete-from (query/honeysql-table-and-alias model)}
+                              resolved-query)]
+    (next-method rf query-type model parsed-args resolved-query)))
 
 (defn reducible-delete
   {:arglists '([modelable & conditions? query?])}

--- a/src/toucan2/insert.clj
+++ b/src/toucan2/insert.clj
@@ -88,7 +88,7 @@
                 (empty? (:rows resolved-query)))
            (nil? resolved-query))))
 
-(m/defmethod pipeline/transduce-resolved-query* [#_query-type :toucan.query-type/insert.*
+(m/defmethod pipeline/transduce-resolved-query [#_query-type :toucan.query-type/insert.*
                                                  #_model      :default
                                                  #_query      :default]
   [rf query-type model parsed-args resolved-query]
@@ -114,7 +114,7 @@
                [modelable k v & more]
                [modelable columns row-vectors])}
   [& unparsed-args]
-  (pipeline/transduce-unparsed :toucan.query-type/insert.update-count unparsed-args))
+  (pipeline/transduce-unparsed-with-default-rf :toucan.query-type/insert.update-count unparsed-args))
 
 (defn reducible-insert-returning-pks
   {:arglists '([modelable row-or-rows]
@@ -133,7 +133,7 @@
                [modelable k v & more]
                [modelable columns row-vectors])}
   [& unparsed-args]
-  (pipeline/transduce-unparsed :toucan.query-type/insert.pks unparsed-args))
+  (pipeline/transduce-unparsed-with-default-rf :toucan.query-type/insert.pks unparsed-args))
 
 (defn reducible-insert-returning-instances
   {:arglists '([modelable row-or-rows]
@@ -158,4 +158,4 @@
                [[modelable & columns-to-return] k v & more]
                [[modelable & columns-to-return] columns row-vectors])}
   [& unparsed-args]
-  (pipeline/transduce-unparsed :toucan.query-type/insert.instances unparsed-args))
+  (pipeline/transduce-unparsed-with-default-rf :toucan.query-type/insert.instances unparsed-args))

--- a/src/toucan2/insert.clj
+++ b/src/toucan2/insert.clj
@@ -24,13 +24,9 @@
    :rows-or-queryable (s/alt :rows      ::args.rows
                              :queryable some?)))
 
-(m/defmethod query/args-spec :toucan.query-type/insert.*
-  [_query-type]
-  ::args)
-
 (defn parse-insert-args
   [query-type unparsed-args]
-  (let [parsed                               (query/parse-args query-type unparsed-args)
+  (let [parsed                               (query/parse-args query-type ::args unparsed-args)
         [rows-queryable-type rows-queryable] (:rows-or-queryable parsed)
         parsed                               (select-keys parsed [:modelable :columns])]
     (case rows-queryable-type

--- a/src/toucan2/insert.clj
+++ b/src/toucan2/insert.clj
@@ -28,9 +28,9 @@
   [_query-type]
   ::args)
 
-(m/defmethod query/parse-args :toucan.query-type/insert.*
+(defn parse-insert-args
   [query-type unparsed-args]
-  (let [parsed                               (next-method query-type unparsed-args)
+  (let [parsed                               (query/parse-args query-type unparsed-args)
         [rows-queryable-type rows-queryable] (:rows-or-queryable parsed)
         parsed                               (select-keys parsed [:modelable :columns])]
     (case rows-queryable-type
@@ -47,6 +47,11 @@
                               :columns-rows      (let [{:keys [columns rows]} x]
                                                    (mapv (partial zipmap columns)
                                                          rows))))))))
+
+(m/defmethod pipeline/transduce-unparsed :toucan.query-type/insert.*
+  [rf query-type unparsed-args]
+  (let [parsed-args (parse-insert-args query-type unparsed-args)]
+    (pipeline/transduce-parsed-args rf query-type parsed-args)))
 
 ;;; Support
 ;;;

--- a/src/toucan2/pipeline.clj
+++ b/src/toucan2/pipeline.clj
@@ -2,13 +2,11 @@
   "This is a low-level namespace implementing our query execution pipeline. Most of the stuff you'd use on a regular basis
   are implemented on top of stuff here."
   (:require
-   [clojure.spec.alpha :as s]
    [methodical.core :as m]
    [methodical.util.trace :as m.trace]
    [pretty.core :as pretty]
    [toucan2.compile :as compile]
    [toucan2.connection :as conn]
-   [toucan2.instance :as instance]
    [toucan2.jdbc.query :as jdbc.query]
    [toucan2.model :as model]
    [toucan2.query :as query]
@@ -84,145 +82,33 @@
 
 ;;;; pipeline
 
+(def ^:dynamic *call-count-thunk*
+  "Thunk function to call every time a query is executed if [[toucan2.execute/with-call-count]] is in use. Implementees
+  of [[transduce-compiled-query-with-connection]] should invoke this every time a query gets executed. You can
+  use [[increment-call-count!]] to simplify the chore of making sure it's non-`nil` before invoking it."
+  nil)
+
+(defn increment-call-count! []
+  (when *call-count-thunk* (*call-count-thunk*)))
+
 ;;; The little subscripts below are so you can tell at a glance which args are used for dispatch.
 
 (defn- dispatch-ignore-rf [f]
   (fn [_rf & args]
     (apply f args)))
 
-(m/defmulti transduce-unparsed*
-  "The first step in the query execution pipeline. Called with the unparsed args as passed to something
-  like [[toucan2.select/select]], before parsing the args.
+;;;; [[transduce-compiled-query-with-connection]]
 
-  ```
-  Entrypoint e.g. select/select
-  ↓
-  transduce-unparsed*           ← YOU ARE HERE
-  ↓
-  toucan2.query/parse-args
-  ↓
-  transduce-parsed-args*
-  ```
-
-  The default implementation parses the args with [[toucan2.query/parse-args]] and then
-  calls [[transduce-parsed-args*]]."
-  {:arglists '([rf query-type₁ unparsed])}
-  (dispatch-ignore-rf u/dispatch-on-first-arg))
-
-(m/defmulti transduce-parsed-args*
-  "The second step in the query execution pipeline. Called with args as parsed by [[toucan2.query/parse-args]].
-
-  ```
-  transduce-unparsed*
-  ↓
-  toucan2.query/parse-args
-  ↓
-  transduce-parsed-args* ← YOU ARE HERE
-  ↓
-  toucan2.model/with-model
-  ↓
-  transduce-with-model*
-  ```
-
-  The default implementation resolves the `:modelable` in `parsed-args` with [[toucan2.model/with-model]] and then
-  calls [[transduce-with-model*]]."
-  {:arglists '([rf query-type₁ parsed-args])}
-  (dispatch-ignore-rf u/dispatch-on-first-arg))
-
-(m/defmulti transduce-with-model*
-  "The third step in the query execution pipeline. This is the first step that dispatches off of resolved model.
-
-  ```
-  transduce-parsed-args*
-  ↓
-  toucan2.model/with-model
-  ↓
-  transduce-with-model* ← YOU ARE HERE
-  ↓
-  toucan2.query/with-resolved-query
-  ↓
-  transduce-resolved-query*
-  ```
-
-  The default implementation resolves the queryable with [[toucan2.query/with-resolved-query]] and then
-  calls [[transduce-resolved-query*]]."
-  {:arglists '([rf query-type₁ model₂ parsed-args])}
-  (dispatch-ignore-rf u/dispatch-on-first-two-args))
-
-(m/defmulti transduce-resolved-query*
-  "The fourth step in the query execution pipeline. Called with a resolved query immediately before 'building' it.
-
-  ```
-  transduce-with-model*
-  ↓
-  toucan2.query/with-resolved-query
-  ↓
-  transduce-resolved-query* ← YOU ARE HERE
-  ↓
-  toucan2.query/with-built-query
-  ↓
-  transduce-built-query*
-  ```
-
-  The default implementation builds the resolved query with [[toucan2.query/with-built-query]] and then
-  calls [[transduce-built-query*]]."
-  {:arglists '([rf query-type₁ model₂ parsed-args resolved-query₃])}
-  (dispatch-ignore-rf
-   (fn [query-type₁ model₂ _parsed-args resolved-query₃]
-     (u/dispatch-on-first-three-args query-type₁ model₂ resolved-query₃))))
-
-(m/defmulti transduce-built-query*
-  "The fifth step in the query execution pipeline. Called with a query that is ready to be compiled, e.g. a fully-formed
-  Honey SQL form.
-
-  ```
-  transduce-resolved-query*
-  ↓
-  toucan2.query/with-built-query
-  ↓
-  transduce-built-query* ← YOU ARE HERE
-  ↓
-  toucan2.compile/with-compiled-query
-  ↓
-  transduce-compiled-query*
-  ```
-
-  The default implementation compiles the query with [[toucan2.compile/with-compiled-query]] and then
-  calls [[transduce-compiled-query*]]."
-  {:arglists '([rf query-type₁ model₂ built-query₃])}
-  (dispatch-ignore-rf u/dispatch-on-first-three-args))
-
-(m/defmulti transduce-compiled-query*
-  "The sixth step in the query execution pipeline. Called with a compiled query that is ready to be executed natively, for
-  example a `[sql & args]` vector, immediately before opening a connection.
-
-  ```
-  transduce-built-query*
-  ↓
-  toucan2.compile/with-compiled-query
-  ↓
-  transduce-compiled-query* ← YOU ARE HERE
-  ↓
-  toucan2.connection/with-connection
-  ↓
-  transduce-compiled-query-with-connection*
-  ```
-
-  The default implementation opens a connection (or uses the current connection)
-  using [[toucan2.connection/with-connection]] and then calls [[transduce-compiled-query-with-connection*]]."
-  {:arglists '([rf query-type₁ model₂ compiled-query₃])}
-  (dispatch-ignore-rf u/dispatch-on-first-three-args))
-
-(m/defmulti transduce-compiled-query-with-connection*
+(m/defmulti ^:dynamic transduce-compiled-query-with-connection
   "The seventh and final step in the query execution pipeline. Called with a fully compiled query that can be executed
   natively, and an open connection for executing it.
 
   ```
-  transduce-compiled-query*
+  transduce-compiled-query
   ↓
   toucan2.connection/with-connection
   ↓
-  transduce-compiled-query-with-connection* ← YOU ARE HERE
+  transduce-compiled-query-with-connection ← YOU ARE HERE
   ↓
   execute query
   ↓
@@ -235,47 +121,269 @@
   {:arglists '([rf conn₁ query-type₂ model₃ compiled-query])}
   (dispatch-ignore-rf u/dispatch-on-first-three-args))
 
-;;;; fn versions.
+(m/defmethod transduce-compiled-query-with-connection :around :default
+  [rf conn query-type model compiled-query]
+  {:pre [(ifn? rf) (some? conn) (isa? query-type :toucan.result-type/*) (some? compiled-query)]}
+  (u/println-debug ["transduce query with %s connection" (symbol (.getCanonicalName (class conn)))])
+  (u/try-with-error-context ["with connection" {:connection (symbol (.getCanonicalName (class conn)))}]
+    (next-method rf conn query-type model compiled-query)))
 
-;;; TODO -- how much are these really used or needed? Can we just make all the multimethods here dynamic instead?
+;;;; [[transduce-compiled-query]]
 
-(def ^:dynamic ^{:arglists '([rf query-type unparsed])}
-  *transduce-unparsed*
-  #'transduce-unparsed*)
+(m/defmulti ^:dynamic transduce-compiled-query
+  "The sixth step in the query execution pipeline. Called with a compiled query that is ready to be executed natively, for
+  example a `[sql & args]` vector, immediately before opening a connection.
 
-(def ^:dynamic ^{:arglists '([rf query-type parsed-args])}
-  *transduce-parsed-args*
-  #'transduce-parsed-args*)
+  ```
+  transduce-built-query
+  ↓
+  toucan2.compile/with-compiled-query
+  ↓
+  transduce-compiled-query ← YOU ARE HERE
+  ↓
+  toucan2.connection/with-connection
+  ↓
+  transduce-compiled-query-with-connection
+  ```
 
-(def ^:dynamic ^{:arglists '([rf query-type model parsed-args])}
-  *transduce-with-model*
-  #'transduce-with-model*)
+  The default implementation opens a connection (or uses the current connection)
+  using [[toucan2.connection/with-connection]] and then calls [[transduce-compiled-query-with-connection]]."
+  {:arglists '([rf query-type₁ model₂ compiled-query₃])}
+  (dispatch-ignore-rf u/dispatch-on-first-three-args))
 
-(def ^:dynamic ^{:arglists '([rf query-type model parsed-args resolved-query])}
-  *transduce-resolved-query*
-  #'transduce-resolved-query*)
+(m/defmethod transduce-compiled-query :around :default
+  [rf query-type model compiled-query]
+  {:pre [(ifn? rf) (isa? query-type :toucan.result-type/*) (some? compiled-query)]}
+  (u/println-debug ["transduce compiled query %s" compiled-query])
+  (u/try-with-error-context ["with compiled query" {:compiled-query compiled-query}]
+    (next-method rf query-type model compiled-query)))
 
-(def ^:dynamic ^{:arglists '([rf query-type model built-query])}
-  *transduce-built-query*
-  #'transduce-built-query*)
+(defn- current-connectable [model]
+  (or conn/*current-connectable*
+      (model/default-connectable model)))
 
-(def ^:dynamic ^{:arglists '([rf query-type model compiled-query])}
-  *transduce-compiled-query*
-  #'transduce-compiled-query*)
+(m/defmethod transduce-compiled-query :default
+  [rf query-type model compiled-query]
+  (conn/with-connection [conn (current-connectable model)]
+    (transduce-compiled-query-with-connection rf conn query-type model compiled-query)))
 
-(def ^:dynamic ^{:arglists '([rf conn query-type model compiled-query])}
-  *transduce-compiled-query-with-connection*
-  #'transduce-compiled-query-with-connection*)
+;;; For DML stuff we will run the whole thing in a transaction if we're not already in one.
+;;;
+;;; Not 100% sure this is necessary since we would probably already be in one if we needed to be because stuff like
+;;; [[toucan2.tools.before-delete]] have to put us in one much earlier.
+(m/defmethod transduce-compiled-query [#_query-type     :toucan.statement-type/DML
+                                        #_model          :default
+                                        #_compiled-query :default]
+  [rf query-type model compiled-query]
+  (conn/with-transaction [_conn (current-connectable model) {:nested-transaction-rule :ignore}]
+    (next-method rf query-type model compiled-query)))
+
+;;;; [[transduce-built-query]]
+
+(m/defmulti ^:dynamic transduce-built-query
+  "The fifth step in the query execution pipeline. Called with a query that is ready to be compiled, e.g. a fully-formed
+  Honey SQL form.
+
+  ```
+  transduce-resolved-query
+  ↓
+  toucan2.query/with-built-query
+  ↓
+  transduce-built-query ← YOU ARE HERE
+  ↓
+  toucan2.compile/with-compiled-query
+  ↓
+  transduce-compiled-query
+  ```
+
+  The default implementation compiles the query with [[toucan2.compile/with-compiled-query]] and then
+  calls [[transduce-compiled-query]]."
+  {:arglists '([rf query-type₁ model₂ built-query₃])}
+  (dispatch-ignore-rf u/dispatch-on-first-three-args))
+
+(m/defmethod transduce-built-query :around :default
+  [rf query-type model built-query]
+  {:pre [(ifn? rf) (isa? query-type :toucan.result-type/*) (some? built-query)]}
+  (u/println-debug ["transduce built query %s" built-query])
+  (u/try-with-error-context ["with built query" {:query-type query-type, :built-query built-query}]
+    (next-method rf query-type model built-query)))
+
+(m/defmethod transduce-built-query :default
+  [rf query-type model built-query]
+  (compile/with-compiled-query [compiled-query [model built-query]]
+    ;; keep the original info around as metadata in case someone needs it later.
+    (let [compiled-query (vary-meta compiled-query #(merge (meta built-query)
+                                                           {::built-query built-query}
+                                                           %))]
+      (transduce-compiled-query rf query-type model compiled-query))))
+
+;;;; [[transduce-resolved-query]]
+
+(m/defmulti ^:dynamic transduce-resolved-query
+  "The fourth step in the query execution pipeline. Called with a resolved query immediately before 'building' it.
+
+  ```
+  transduce-with-model
+  ↓
+  toucan2.query/with-resolved-query
+  ↓
+  transduce-resolved-query ← YOU ARE HERE
+  ↓
+  toucan2.query/with-built-query
+  ↓
+  transduce-built-query
+  ```
+
+  The default implementation builds the resolved query with [[toucan2.query/with-built-query]] and then
+  calls [[transduce-built-query]]."
+  {:arglists '([rf query-type₁ model₂ parsed-args resolved-query₃])}
+  (dispatch-ignore-rf
+   (fn [query-type₁ model₂ _parsed-args resolved-query₃]
+     (u/dispatch-on-first-three-args query-type₁ model₂ resolved-query₃))))
+
+(m/defmethod transduce-resolved-query :around :default
+  [rf query-type model parsed-args resolved-query]
+  {:pre [(ifn? rf) (isa? query-type :toucan.result-type/*) (map? parsed-args)]}
+  (u/println-debug ["transduce resolved query %s" resolved-query])
+  (u/try-with-error-context ["with resolved query" {:query-type     query-type
+                                                    :resolved-query resolved-query
+                                                    :parsed-args    parsed-args}]
+    (next-method rf query-type model parsed-args resolved-query)))
+
+(m/defmethod transduce-resolved-query :default
+  [rf query-type model parsed-args resolved-query]
+  (query/with-built-query [built-query [query-type model parsed-args resolved-query]]
+    ;; keep the original info around as metadata in case someone needs it later.
+    ;;
+    ;; TODO -- consider whether the [[with-built-query]] macro should do this for us.
+    (let [built-query (vary-meta built-query
+                                 assoc
+                                 ;; HACK in case you need it later. (We do.) See if there's a way we could do this
+                                 ;; without a big ol ugly HACK.
+                                 ::resolved-query resolved-query
+                                 ::parsed-args parsed-args)]
+      (transduce-built-query rf query-type model built-query))))
+
+;;;; [[transduce-with-model]]
+
+(m/defmulti ^:dynamic transduce-with-model
+  "The third step in the query execution pipeline. This is the first step that dispatches off of resolved model.
+
+  ```
+  transduce-parsed-args
+  ↓
+  toucan2.model/with-model
+  ↓
+  transduce-with-model ← YOU ARE HERE
+  ↓
+  toucan2.query/with-resolved-query
+  ↓
+  transduce-resolved-query
+  ```
+
+  The default implementation resolves the queryable with [[toucan2.query/with-resolved-query]] and then
+  calls [[transduce-resolved-query]]."
+  {:arglists '([rf query-type₁ model₂ parsed-args])}
+  (dispatch-ignore-rf u/dispatch-on-first-two-args))
+
+(m/defmethod transduce-with-model :around :default
+  [rf query-type model parsed-args]
+  {:pre [(ifn? rf) (isa? query-type :toucan.result-type/*) (map? parsed-args)]}
+  (u/println-debug ["transduce for model %s" model])
+  (u/try-with-error-context ["with model" {:model model}]
+    (next-method rf query-type model parsed-args)))
+
+(m/defmethod transduce-with-model :default
+  [rf query-type model {:keys [queryable], :as parsed-args}]
+  (query/with-resolved-query [resolved-query [model queryable]]
+    ;; disabled for now since it breaks [[toucan2.no-jdbc-poc-test]]... but we should figure out how to fix that and
+    ;; then reenable this.
+    #_(assert (not (keyword? resolved-query))
+              (str (format "This doesn't seem like a RESOLVED query: %s" resolved-query)
+                   \newline
+                   (format "Do you need to implement %s for %s?"
+                           `query/do-with-resolved-query
+                           (m/dispatch-value query/do-with-resolved-query model resolved-query))))
+    (transduce-resolved-query rf query-type model (dissoc parsed-args :queryable) resolved-query)))
+
+;;;; [[transduce-parsed-args]]
+
+(m/defmulti ^:dynamic transduce-parsed-args
+  "The second step in the query execution pipeline. Called with args as parsed by [[toucan2.query/parse-args]].
+
+  ```
+  transduce-unparsed
+  ↓
+  toucan2.query/parse-args
+  ↓
+  transduce-parsed-args ← YOU ARE HERE
+  ↓
+  toucan2.model/with-model
+  ↓
+  transduce-with-model
+  ```
+
+  The default implementation resolves the `:modelable` in `parsed-args` with [[toucan2.model/with-model]] and then
+  calls [[transduce-with-model]]."
+  {:arglists '([rf query-type₁ parsed-args])}
+  (dispatch-ignore-rf u/dispatch-on-first-arg))
+
+(m/defmethod transduce-parsed-args :around :default
+  [rf query-type parsed-args]
+  {:pre [(ifn? rf) (isa? query-type :toucan.result-type/*) (map? parsed-args)]}
+  (u/println-debug ["transduce parsed args %s" parsed-args])
+  (u/try-with-error-context ["with parsed args" {:parsed-args parsed-args}]
+    (next-method rf query-type parsed-args)))
+
+(m/defmethod transduce-parsed-args :default
+  [rf query-type {:keys [modelable], :as parsed-args}]
+  (model/with-model [model modelable]
+    (transduce-with-model rf query-type model (dissoc parsed-args :modelable))))
+
+;;;; [[transduce-unparsed]]
+
+(m/defmulti ^:dynamic transduce-unparsed
+  "The first step in the query execution pipeline. Called with the unparsed args as passed to something
+  like [[toucan2.select/select]], before parsing the args.
+
+  ```
+  Entrypoint e.g. select/select
+  ↓
+  transduce-unparsed           ← YOU ARE HERE
+  ↓
+  toucan2.query/parse-args
+  ↓
+  transduce-parsed-args
+  ```
+
+  The default implementation parses the args with [[toucan2.query/parse-args]] and then
+  calls [[transduce-parsed-args]]."
+  {:arglists '([rf query-type₁ unparsed])}
+  (dispatch-ignore-rf u/dispatch-on-first-arg))
+
+(m/defmethod transduce-unparsed :around :default
+  [rf query-type unparsed]
+  {:pre [(ifn? rf) (isa? query-type :toucan.result-type/*) (sequential? unparsed)]}
+  (u/println-debug ["transduce unparsed %s args %s" query-type unparsed])
+  (u/try-with-error-context ["transduce results" {:query-type query-type, :unparsed unparsed}]
+    (next-method rf query-type unparsed)))
+
+(m/defmethod transduce-unparsed :default
+  [rf query-type unparsed]
+  (let [parsed-args (query/parse-args query-type unparsed)]
+    (transduce-parsed-args rf query-type parsed-args)))
 
 ;;;; rf helper functions
 
-(defn with-init [rf init]
+(defn with-init
+  "Returns a version of reducing function `rf` with a zero-arity (initial value arity) that returns `init`."
+  [rf init]
   (fn
     ([]    init)
     ([x]   (rf x))
     ([x y] (rf x y))))
 
-(m/defmulti default-rf
+(m/defmulti ^:dynamic default-rf
   {:arglists '([query-type])}
   keyword)
 
@@ -293,146 +401,19 @@
 (defn first-result-rf [rf]
   (completing ((take 1) rf) first))
 
-;;;; function wrappers for the underlying methods.
+;;;; Helper functions for implementing stuff like [[toucan2.select/select]]
 
-(defn transduce-unparsed
-  ([query-type unparsed]
-   (assert (isa? query-type :toucan.result-type/*))
-   (let [rf (default-rf query-type)]
-     (transduce-unparsed rf query-type unparsed)))
-
-  ([rf query-type unparsed]
-   {:pre [(ifn? rf) (isa? query-type :toucan.result-type/*) (sequential? unparsed)]}
-   (u/println-debug ["transduce unparsed %s args %s" query-type unparsed])
-   (u/try-with-error-context ["transduce results" {:query-type query-type, :unparsed unparsed}]
-     (*transduce-unparsed* rf query-type unparsed))))
+(defn transduce-unparsed-with-default-rf [query-type unparsed]
+  (assert (isa? query-type :toucan.result-type/*))
+  (let [rf (default-rf query-type)]
+    (transduce-unparsed rf query-type unparsed)))
 
 (defn transduce-unparsed-first-result [query-type unparsed]
   (let [rf (default-rf query-type)]
     (transduce-unparsed (first-result-rf rf) query-type unparsed)))
 
-(defn transduce-parsed-args
-  [rf query-type parsed-args]
-  {:pre [(ifn? rf) (isa? query-type :toucan.result-type/*) (map? parsed-args)]}
-  (u/println-debug ["transduce parsed args %s" parsed-args])
-  (u/try-with-error-context ["with parsed args" {:parsed-args parsed-args}]
-    (*transduce-parsed-args* rf query-type parsed-args)))
 
-(defn transduce-with-model
-  [rf query-type model parsed-args]
-  {:pre [(ifn? rf) (isa? query-type :toucan.result-type/*) (map? parsed-args)]}
-  (u/println-debug ["transduce for model %s" model])
-  (u/try-with-error-context ["with model" {:model model}]
-    (*transduce-with-model* rf query-type model parsed-args)))
-
-(defn transduce-resolved-query
-  [rf query-type model parsed-args resolved-query]
-  {:pre [(ifn? rf) (isa? query-type :toucan.result-type/*) (map? parsed-args)]}
-  (u/println-debug ["transduce resolved query %s" resolved-query])
-  (u/try-with-error-context ["with resolved query" {:query-type     query-type
-                                                    :resolved-query resolved-query
-                                                    :parsed-args    parsed-args}]
-    (*transduce-resolved-query* rf query-type model parsed-args resolved-query)))
-
-(defn transduce-built-query
-  [rf query-type model built-query]
-  {:pre [(ifn? rf) (isa? query-type :toucan.result-type/*) (some? built-query)]}
-  (u/println-debug ["transduce built query %s" built-query])
-  (u/try-with-error-context ["with built query" {:query-type query-type, :built-query built-query}]
-    (*transduce-built-query* rf query-type model built-query)))
-
-(defn transduce-compiled-query
-  [rf query-type model compiled-query]
-  {:pre [(ifn? rf) (isa? query-type :toucan.result-type/*) (some? compiled-query)]}
-  (u/println-debug ["transduce compiled query %s" compiled-query])
-  (u/try-with-error-context ["with compiled query" {:compiled-query compiled-query}]
-    (*transduce-compiled-query* rf query-type model compiled-query)))
-
-(defn transduce-compiled-query-with-connection
-  [rf conn query-type model compiled-query]
-  {:pre [(ifn? rf) (some? conn) (isa? query-type :toucan.result-type/*) (some? compiled-query)]}
-  (u/println-debug ["transduce query with %s connection" (symbol (.getCanonicalName (class conn)))])
-  (u/try-with-error-context ["with connection" {:connection (symbol (.getCanonicalName (class conn)))}]
-    (*transduce-compiled-query-with-connection* rf conn query-type model compiled-query)))
-
-;;;; default impls
-
-(def ^:dynamic *call-count-thunk*
-  "Thunk function to call every time a query is executed if [[toucan2.execute/with-call-count]] is in use. Implementees
-  of [[transduce-compiled-query-with-connection*]] should invoke this every time a query gets executed. You can
-  use [[increment-call-count!]] to simplify the chore of making sure it's non-`nil` before invoking it."
-  nil)
-
-(defn increment-call-count! []
-  (when *call-count-thunk* (*call-count-thunk*)))
-
-(m/defmethod transduce-unparsed* :default
-  [rf query-type unparsed]
-  (let [parsed-args (query/parse-args query-type unparsed)]
-    (transduce-parsed-args rf query-type parsed-args)))
-
-(m/defmethod transduce-parsed-args* :default
-  [rf query-type {:keys [modelable], :as parsed-args}]
-  (model/with-model [model modelable]
-    (transduce-with-model rf query-type model (dissoc parsed-args :modelable))))
-
-(m/defmethod transduce-with-model* :default
-  [rf query-type model {:keys [queryable], :as parsed-args}]
-  (query/with-resolved-query [resolved-query [model queryable]]
-    ;; disabled for now since it breaks [[toucan2.no-jdbc-poc-test]]... but we should figure out how to fix that and
-    ;; then reenable this.
-    #_(assert (not (keyword? resolved-query))
-              (str (format "This doesn't seem like a RESOLVED query: %s" resolved-query)
-                   \newline
-                   (format "Do you need to implement %s for %s?"
-                           `query/do-with-resolved-query
-                           (m/dispatch-value query/do-with-resolved-query model resolved-query))))
-    (transduce-resolved-query rf query-type model (dissoc parsed-args :queryable) resolved-query)))
-
-(m/defmethod transduce-resolved-query* :default
-  [rf query-type model parsed-args resolved-query]
-  (query/with-built-query [built-query [query-type model parsed-args resolved-query]]
-    ;; keep the original info around as metadata in case someone needs it later.
-    ;;
-    ;; TODO -- consider whether the [[with-built-query]] macro should do this for us.
-    (let [built-query (vary-meta built-query
-                                 assoc
-                                 ;; HACK in case you need it later. (We do.) See if there's a way we could do this
-                                 ;; without a big ol ugly HACK.
-                                 ::resolved-query resolved-query
-                                 ::parsed-args parsed-args)]
-      (transduce-built-query rf query-type model built-query))))
-
-(m/defmethod transduce-built-query* :default
-  [rf query-type model built-query]
-  (compile/with-compiled-query [compiled-query [model built-query]]
-    ;; keep the original info around as metadata in case someone needs it later.
-    (let [compiled-query (vary-meta compiled-query #(merge (meta built-query)
-                                                           {::built-query built-query}
-                                                           %))]
-      (transduce-compiled-query rf query-type model compiled-query))))
-
-(defn- current-connectable [model]
-  (or conn/*current-connectable*
-      (model/default-connectable model)))
-
-(m/defmethod transduce-compiled-query* :default
-  [rf query-type model compiled-query]
-  (conn/with-connection [conn (current-connectable model)]
-    (transduce-compiled-query-with-connection rf conn query-type model compiled-query)))
-
-;;; For DML stuff we will run the whole thing in a transaction if we're not already in one.
-;;;
-;;; Not 100% sure this is necessary since we would probably already be in one if we needed to be because stuff like
-;;; [[toucan2.tools.before-delete]] have to put us in one much earlier.
-(m/defmethod transduce-compiled-query* [#_query-type     :toucan.statement-type/DML
-                                        #_model          :default
-                                        #_compiled-query :default]
-  [rf query-type model compiled-query]
-  (conn/with-transaction [_conn (current-connectable model) {:nested-transaction-rule :ignore}]
-    (next-method rf query-type model compiled-query)))
-
-;;;; reducible versions
+;;;; reducible versions for implementing stuff like [[toucan2.select/reducible-select]]
 
 (defn- reducible-fn
   "Create a reducible with one of the functions in this namespace."
@@ -475,35 +456,6 @@
   [conn query-type model compiled-query]
   (reducible-fn transduce-compiled-query-with-connection conn query-type model compiled-query))
 
-;;;; proof-of-concept: simple out transform
-
-;;; TODO -- move this to `tools`.
-
-(defmacro define-out-transform
-  {:style/indent :defn}
-  [[query-type model-type] [instance-binding] & body]
-  `(m/defmethod transduce-with-model* :around [~query-type ~model-type]
-     [rf# ~'&query-type ~'&model ~'&parsed-args]
-     (let [rf*# ((map (fn [~instance-binding]
-                        (let [instance# (do ~@body)]
-                          (cond-> instance#
-                            (instance/instance? instance#)
-                            instance/reset-original))))
-                 rf#)]
-       (~'next-method rf*# ~'&query-type ~'&model ~'&parsed-args))))
-
-(s/fdef define-out-transform
-  :args (s/cat :dispatch-value (s/spec (s/cat :query-type keyword?
-                                              :model-type any?))
-               :bindings (s/spec (s/cat :row :clojure.core.specs.alpha/binding-form))
-               :body     (s/+ any?))
-  :ret any?)
-
-(comment
-  (define-out-transform [:toucan.query-type/select.instances ::venues]
-    [row]
-    (assoc row :neat true)))
-
 ;;;; utils
 
 (defn parent-query-type [query-type]
@@ -544,7 +496,7 @@
 
 ;;;; default JDBC impls. Not convinced they belong here.
 
-(m/defmethod transduce-compiled-query-with-connection* [#_connection java.sql.Connection
+(m/defmethod transduce-compiled-query-with-connection [#_connection java.sql.Connection
                                                         #_query-type :default
                                                         #_model      :default]
   [rf conn query-type model sql-args]
@@ -559,7 +511,7 @@
 ;;; To get Databases to return the generated primary keys rather than the update count for SELECT/UPDATE/DELETE we need
 ;;; to set the `next.jdbc` option `:return-keys true`
 
-(m/defmethod transduce-compiled-query-with-connection* [#_connection java.sql.Connection
+(m/defmethod transduce-compiled-query-with-connection [#_connection java.sql.Connection
                                                         #_query-type :toucan.result-type/pks
                                                         #_model      :default]
   [rf conn query-type model sql-args]
@@ -594,7 +546,7 @@
                        :queryable {}}]
       (transduce-with-model rf ::select.instances-from-pks model parsed-args))))
 
-(m/defmethod transduce-compiled-query-with-connection* [#_connection java.sql.Connection
+(m/defmethod transduce-compiled-query-with-connection [#_connection java.sql.Connection
                                                         #_query-type :toucan.result-type/instances
                                                         #_model      :default]
   [rf conn query-type model sql-args]
@@ -615,7 +567,7 @@
       ;; actual instances to the original `rf` once we get them.
       ;;
       ;;
-      (let [pks     (transduce-compiled-query-with-connection* conj conn pk-query-type model sql-args)
+      (let [pks     (transduce-compiled-query-with-connection conj conn pk-query-type model sql-args)
             ;; this is sort of a hack but I don't know of any other way to pass along `:columns` information with the
             ;; original parsed args
             columns (get-in (meta sql-args) [::parsed-args :columns])]
@@ -630,11 +582,11 @@
             (partial m.trace/trace* (vary-meta (var-get varr)
                                                assoc
                                                ::m.trace/description (symbol varr))))]
-    (binding [*transduce-unparsed*                       (traced-var #'transduce-unparsed*)
-              *transduce-parsed-args*                    (traced-var #'transduce-parsed-args*)
-              *transduce-with-model*                     (traced-var #'transduce-with-model*)
-              *transduce-resolved-query*                 (traced-var #'transduce-resolved-query*)
-              *transduce-built-query*                    (traced-var #'transduce-built-query*)
-              *transduce-compiled-query*                 (traced-var #'transduce-compiled-query*)
-              *transduce-compiled-query-with-connection* (traced-var #'transduce-compiled-query-with-connection*)]
+    (binding [transduce-unparsed                       (traced-var #'transduce-unparsed)
+              transduce-parsed-args                    (traced-var #'transduce-parsed-args)
+              transduce-with-model                     (traced-var #'transduce-with-model)
+              transduce-resolved-query                 (traced-var #'transduce-resolved-query)
+              transduce-built-query                    (traced-var #'transduce-built-query)
+              transduce-compiled-query                 (traced-var #'transduce-compiled-query)
+              transduce-compiled-query-with-connection (traced-var #'transduce-compiled-query-with-connection)]
       (thunk))))

--- a/src/toucan2/pipeline.clj
+++ b/src/toucan2/pipeline.clj
@@ -629,8 +629,9 @@
 (defn- transduce-instances-from-pks
   [rf model columns pks]
   ;; make sure [[toucan2.select]] is loaded so we get the impls for `:toucan.query-type/select.instances`
-  (locking clojure.lang.RT/REQUIRE_LOCK
-    (require 'toucan2.select))
+  (when-not (contains? (loaded-libs) 'toucan2.select)
+    (locking clojure.lang.RT/REQUIRE_LOCK
+      (require 'toucan2.select)))
   (if (empty? pks)
     []
     (let [kv-args     {:toucan/pk [:in pks]}

--- a/src/toucan2/pipeline.clj
+++ b/src/toucan2/pipeline.clj
@@ -309,12 +309,13 @@
 ;;;; [[transduce-parsed-args]]
 
 (m/defmulti ^:dynamic transduce-parsed-args
-  "The second step in the query execution pipeline. Called with args as parsed by [[toucan2.query/parse-args]].
+  "The second step in the query execution pipeline. Called with args as parsed by something like
+  [[toucan2.query/parse-args]].
 
   ```
   transduce-unparsed
   ↓
-  toucan2.query/parse-args
+  (parse args)
   ↓
   transduce-parsed-args ← YOU ARE HERE
   ↓
@@ -351,14 +352,14 @@
   ↓
   transduce-unparsed           ← YOU ARE HERE
   ↓
-  toucan2.query/parse-args
+  (parse args)
   ↓
   transduce-parsed-args
   ```
 
   The default implementation parses the args with [[toucan2.query/parse-args]] and then
   calls [[transduce-parsed-args]]."
-  {:arglists '([rf query-type₁ unparsed])}
+  {:arglists '([rf query-type₁ unparsed-args])}
   (dispatch-ignore-rf u/dispatch-on-first-arg))
 
 (m/defmethod transduce-unparsed :around :default

--- a/src/toucan2/select.clj
+++ b/src/toucan2/select.clj
@@ -32,7 +32,7 @@
   {:arglists '([modelable & kv-args? query?]
                [[modelable & columns] & kv-args? query?])}
   [& unparsed-args]
-  (pipeline/transduce-unparsed :toucan.query-type/select.instances unparsed-args))
+  (pipeline/transduce-unparsed-with-default-rf :toucan.query-type/select.instances unparsed-args))
 
 (defn select-one {:arglists '([modelable & kv-args? query?]
                               [[modelable & columns] & kv-args? query?])}

--- a/src/toucan2/tools/after.clj
+++ b/src/toucan2/tools/after.clj
@@ -63,9 +63,9 @@
                          row)))))]
     ((map row-fn) rf)))
 
-(m/defmethod pipeline/transduce-compiled-query* [#_query-type     ::query-type
-                                                 #_model          ::model
-                                                 #_compiled-query :default]
+(m/defmethod pipeline/transduce-compiled-query [#_query-type     ::query-type
+                                                #_model          ::model
+                                                #_compiled-query :default]
   [rf query-type model sql-args]
   (let [upgraded-type (pipeline/similar-query-type-returning query-type :toucan.result-type/instances)
         _             (assert upgraded-type (format "Don't know how to upgrade a %s query to one returning instances"

--- a/src/toucan2/tools/after_select.clj
+++ b/src/toucan2/tools/after_select.clj
@@ -1,12 +1,12 @@
 (ns toucan2.tools.after-select
   (:require
    [clojure.spec.alpha :as s]
-   [toucan2.pipeline :as pipeline]))
+   [toucan2.tools.simple-out-transform :as tools.simple-out-transform]))
 
 (defmacro define-after-select
   {:style/indent :defn}
   [model [instance-binding] & body]
-  `(pipeline/define-out-transform [:toucan.query-type/select.instances ~model]
+  `(tools.simple-out-transform/define-out-transform [:toucan.query-type/select.instances ~model]
      [instance#]
      ;; don't do after-select if this select is a result of doing something like insert-returning instances
      (if (isa? ~'&query-type :toucan2.pipeline/select.instances-from-pks)

--- a/src/toucan2/tools/before_delete.clj
+++ b/src/toucan2/tools/before_delete.clj
@@ -18,7 +18,6 @@
   (u/with-debug-result (list `before-delete model instance)
     (next-method model instance)))
 
-;;; TODO -- this should probably be done in `with-resolved-query` ?
 (m/defmethod pipeline/transduce-with-model :before [#_query-type :toucan.query-type/delete.*
                                                     #_model      ::before-delete]
   [_rf _query-type model parsed-args]

--- a/src/toucan2/tools/before_delete.clj
+++ b/src/toucan2/tools/before_delete.clj
@@ -19,8 +19,8 @@
     (next-method model instance)))
 
 ;;; TODO -- this should probably be done in `with-resolved-query` ?
-(m/defmethod pipeline/transduce-with-model* :before [#_query-type :toucan.query-type/delete.*
-                                                     #_model      ::before-delete]
+(m/defmethod pipeline/transduce-with-model :before [#_query-type :toucan.query-type/delete.*
+                                                    #_model      ::before-delete]
   [_rf _query-type model parsed-args]
   (conn/with-transaction [_conn
                           (or conn/*current-connectable*

--- a/src/toucan2/tools/before_delete.clj
+++ b/src/toucan2/tools/before_delete.clj
@@ -18,23 +18,29 @@
   (u/with-debug-result (list `before-delete model instance)
     (next-method model instance)))
 
+(def ^:private ^:dynamic *in-before-delete* false)
+
 (m/defmethod pipeline/transduce-with-model :before [#_query-type :toucan.query-type/delete.*
                                                     #_model      ::before-delete]
   [_rf _query-type model parsed-args]
-  (conn/with-transaction [_conn
-                          (or conn/*current-connectable*
-                              (model/default-connectable model))
-                          {:nested-transaction-rule :ignore}]
-    ;; select and transduce the matching rows and run their [[before-delete]] methods
-    (pipeline/transduce-with-model
-     ((map (fn [row]
-             (before-delete model row)))
-      (constantly nil))
-     :toucan.query-type/select.instances
-     model
-     parsed-args)
-    ;; cool, now we can proceed
-    parsed-args))
+  ;; prevent unnecessary duplicate before deletes
+  (if *in-before-delete*
+    parsed-args
+    (binding [*in-before-delete* true]
+      (conn/with-transaction [_conn
+                              (or conn/*current-connectable*
+                                  (model/default-connectable model))
+                              {:nested-transaction-rule :ignore}]
+        ;; select and transduce the matching rows and run their [[before-delete]] methods
+        (pipeline/transduce-with-model
+         ((map (fn [row]
+                 (before-delete model row)))
+          (constantly nil))
+         :toucan.query-type/select.instances
+         model
+         parsed-args)
+        ;; cool, now we can proceed
+        parsed-args))))
 
 (defn ^:no-doc before-delete-impl [next-method model instance f]
   (let [result (or (f model instance)

--- a/src/toucan2/tools/before_insert.clj
+++ b/src/toucan2/tools/before_insert.clj
@@ -19,15 +19,15 @@
 
 ;;; make sure we transform rows whether it's in the parsed args or in the resolved query.
 
-(m/defmethod pipeline/transduce-with-model* :before [#_query-type :toucan.query-type/insert.*
+(m/defmethod pipeline/transduce-with-model :before [#_query-type :toucan.query-type/insert.*
                                                      #_model      ::before-insert]
   [_rf _query-type model parsed-args]
   (cond-> parsed-args
     (:rows parsed-args) (update :rows do-before-insert-to-rows model)))
 
-(m/defmethod pipeline/transduce-resolved-query* :before [#_query-type :toucan.query-type/insert.*
-                                                         #_model      ::before-insert
-                                                         #_query      clojure.lang.IPersistentMap]
+(m/defmethod pipeline/transduce-resolved-query :before [#_query-type :toucan.query-type/insert.*
+                                                        #_model      ::before-insert
+                                                        #_query      clojure.lang.IPersistentMap]
   [_rf _query-type model _parsed-args resolved-query]
   (cond-> resolved-query
     (:rows resolved-query) (update :rows do-before-insert-to-rows model)))
@@ -38,7 +38,7 @@
 ;;;
 ;;; By marking `::before-insert` as preferred over `:toucan2.tools.transformed/transformed` it will be done first (see
 ;;; https://github.com/camsaul/methodical#before-methods)
-(m/prefer-method! #'pipeline/transduce-with-model*
+(m/prefer-method! #'pipeline/transduce-with-model
                   [:toucan.query-type/insert.* ::before-insert]
                   [:toucan.query-type/insert.* :toucan2.tools.transformed/transformed.model])
 

--- a/src/toucan2/tools/before_update.clj
+++ b/src/toucan2/tools/before_update.clj
@@ -61,7 +61,7 @@
                 pk-map            pk-maps]
             (assoc parsed-args :changes changes, :kv-args pk-map)))))))
 
-(m/defmethod pipeline/transduce-with-model* :around [:toucan.query-type/update.* ::before-update]
+(m/defmethod pipeline/transduce-with-model :around [:toucan.query-type/update.* ::before-update]
   [rf query-type model {::keys [doing-before-update?], :keys [changes], :as parsed-args}]
   (cond
     doing-before-update?

--- a/src/toucan2/tools/compile.clj
+++ b/src/toucan2/tools/compile.clj
@@ -15,16 +15,16 @@
   ```"
   {:style/indent 0}
   [& body]
-  `(binding [pipeline/*transduce-compiled-query* (fn [rf# query-type# model# compiled-query#]
-                                                   compiled-query#)]
+  `(binding [pipeline/transduce-compiled-query (fn [rf# query-type# model# compiled-query#]
+                                                 compiled-query#)]
      ~@body))
 
 (defmacro build
   "Return the built query before compilation that would have been executed by `body` without compiling or executing it."
   {:style/indent 0}
   [& body]
-  `(binding [pipeline/*transduce-built-query* (fn [rf# query-type# model# built-query#]
-                                                built-query#)]
+  `(binding [pipeline/transduce-built-query (fn [rf# query-type# model# built-query#]
+                                              built-query#)]
      ~@body))
 
 (defmacro resolved
@@ -32,8 +32,8 @@
   args passed to [[toucan2.select/select]] created by `body` without building a query, compiling it, or executing it."
   {:style/indent 0}
   [& body]
-  `(binding [pipeline/*transduce-resolved-query* (fn [rf# query-type# model# parsed-args# resolved-query#]
-                                                   {:parsed-args parsed-args#, :resolved-query resolved-query#})]
+  `(binding [pipeline/transduce-resolved-query (fn [rf# query-type# model# parsed-args# resolved-query#]
+                                                 {:parsed-args parsed-args#, :resolved-query resolved-query#})]
      ~@body))
 
 ;; (defmacro parsed-args

--- a/src/toucan2/tools/default_fields.clj
+++ b/src/toucan2/tools/default_fields.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.spec.alpha :as s]
    [methodical.core :as m]
-   [toucan2.query :as query]
+   [toucan2.pipeline :as pipeline]
    [toucan2.util :as u]))
 
 (set! *warn-on-reflection* true)
@@ -11,14 +11,13 @@
   {:arglists '([model])}
   u/dispatch-on-first-arg)
 
-(m/defmethod query/build :before [#_query-type :toucan.result-type/instances
-                                  #_model      ::default-fields
-                                  #_query      clojure.lang.IPersistentMap]
-  [_query-type model args]
+(m/defmethod pipeline/transduce-with-model :before [#_query-type :toucan.result-type/instances
+                                                    #_model      ::default-fields]
+  [_rf _query-type model parsed-args]
   (u/with-debug-result ["add default fields for %s" model]
-    (update args :columns (fn [columns]
-                            (or (not-empty columns)
-                                (default-fields model))))))
+    (update parsed-args :columns (fn [columns]
+                                   (or (not-empty columns)
+                                       (default-fields model))))))
 
 (defmacro define-default-fields {:style/indent :defn} [model & body]
   `(let [model# ~model]

--- a/src/toucan2/tools/disallow.clj
+++ b/src/toucan2/tools/disallow.clj
@@ -3,18 +3,18 @@
    [methodical.core :as m]
    [toucan2.pipeline :as pipeline]))
 
-(m/defmethod pipeline/transduce-with-model* [:toucan.query-type/select.* ::select]
+(m/defmethod pipeline/transduce-with-model [:toucan.query-type/select.* ::select]
   [_rf _query-type model _parsed-args]
   (throw (UnsupportedOperationException. (format "You cannot select %s." model))))
 
-(m/defmethod pipeline/transduce-with-model* [:toucan.query-type/delete.* ::delete]
+(m/defmethod pipeline/transduce-with-model [:toucan.query-type/delete.* ::delete]
   [_rf _query-type model _parsed-args]
   (throw (UnsupportedOperationException. (format "You cannot delete instances of %s." model))))
 
-(m/defmethod pipeline/transduce-with-model* [:toucan.query-type/insert.* ::insert]
+(m/defmethod pipeline/transduce-with-model [:toucan.query-type/insert.* ::insert]
   [_rf _query-type model _parsed-args]
   (throw (UnsupportedOperationException. (format "You cannot create new instances of %s." model))))
 
-(m/defmethod pipeline/transduce-with-model* [:toucan.query-type/update.* ::update]
+(m/defmethod pipeline/transduce-with-model [:toucan.query-type/update.* ::update]
   [_rf _query-type model _parsed-args]
   (throw (UnsupportedOperationException. (format "You cannot update a %s after it has been created." model))))

--- a/src/toucan2/tools/identity_query.clj
+++ b/src/toucan2/tools/identity_query.clj
@@ -5,7 +5,6 @@
    [toucan2.connection :as conn]
    [toucan2.instance :as instance]
    [toucan2.pipeline :as pipeline]
-   [toucan2.query :as query]
    [toucan2.realize :as realize]
    [toucan2.util :as u]))
 
@@ -56,18 +55,18 @@
 
 ;;; this is an around method so we can intercept anything else that might normally be considered a more specific method
 ;;; when it dispatches off of more-specific values of `query-type`
-(m/defmethod query/build :around [#_query-type :default
-                                  #_model      :default
-                                  #_query      IdentityQuery]
-  [_query-type _model {:keys [query], :as _args}]
-  query)
+(m/defmethod pipeline/transduce-resolved-query :around [#_query-type :default
+                                                        #_model      :default
+                                                        #_query      IdentityQuery]
+  [rf query-type model _parsed-args resolved-query]
+  (pipeline/transduce-built-query rf query-type model resolved-query))
 
 ;;; TODO -- not sure we need this method since we should be bypassing it with the method below
-(m/defmethod query/build [#_query-type :default
-                          #_model      IdentityQuery
-                          #_query      :default]
-  [_query-type _model {:keys [query], :as _args}]
-  query)
+(m/defmethod pipeline/transduce-resolved-query [#_query-type :default
+                                                #_model      IdentityQuery
+                                                #_query      :default]
+  [rf query-type model _parsed-args resolved-query]
+  (pipeline/transduce-built-query rf query-type model resolved-query))
 
 ;;; allow using an identity query as an 'identity model'
 (m/defmethod pipeline/transduce-with-model [#_query-type :default

--- a/src/toucan2/tools/identity_query.clj
+++ b/src/toucan2/tools/identity_query.clj
@@ -42,9 +42,9 @@
   [reducible-rows]
   (->IdentityQuery reducible-rows))
 
-(m/defmethod pipeline/transduce-built-query* [#_query-type :default #_:toucan.result-type/instances
-                                              #_model      :default
-                                              #_query      IdentityQuery]
+(m/defmethod pipeline/transduce-built-query [#_query-type :default
+                                             #_model      :default
+                                             #_query      IdentityQuery]
   [rf _query-type model {:keys [rows], :as _query}]
   (u/with-debug-result ["transduce IdentityQuery rows %s" rows]
     (transduce (if model
@@ -70,8 +70,8 @@
   query)
 
 ;;; allow using an identity query as an 'identity model'
-(m/defmethod pipeline/transduce-with-model* [#_query-type :default
-                                             #_model      IdentityQuery]
+(m/defmethod pipeline/transduce-with-model [#_query-type :default
+                                            #_model      IdentityQuery]
   [rf _query-type model _parsed-args]
   (transduce identity rf model))
 
@@ -91,9 +91,9 @@
   [connectable _options f]
   (f connectable))
 
-(m/defmethod pipeline/transduce-compiled-query-with-connection* [#_conn       IdentityConnection
-                                                                 #_query-type :default
-                                                                 #_model      :default]
+(m/defmethod pipeline/transduce-compiled-query-with-connection [#_conn       IdentityConnection
+                                                                #_query-type :default
+                                                                #_model      :default]
   [rf conn _query-type model _compiled-query]
   (transduce
    (map (fn [row]

--- a/src/toucan2/tools/named_query.clj
+++ b/src/toucan2/tools/named_query.clj
@@ -1,0 +1,36 @@
+(ns toucan2.tools.named-query
+  (:require
+   [clojure.spec.alpha :as s]
+   [methodical.core :as m]
+   [toucan2.pipeline :as pipeline]))
+
+;;;; This doesn't NEED to be a macro but having the definition live in the namespace it was defined in is useful for
+;;;; stack trace purposes. Also it lets us do validation with the spec below.
+(defmacro define-named-query
+  "Helper for defining 'named' queries.
+
+  ```clj
+  ;; define a custom query ::my-count that you can then use with select and the like
+  (define-named-query ::my-count
+    {:select [:%count.*], :from [(keyword (model/table-name model))]})
+
+  (select :model/user ::my-count)
+  ```"
+  {:style/indent 1}
+  ([query-name resolved-query]
+   `(define-named-query ~query-name :default :default ~resolved-query))
+
+  ([query-name query-type model resolved-query]
+   `(m/defmethod pipeline/transduce-unresolved-query [~query-type ~model ~query-name]
+      [rf# ~'&query-type ~'&model ~'&parsed-args ~'&unresolved-query]
+      (~'next-method rf# ~'&query-type ~'&model ~'&parsed-args ~resolved-query))))
+
+(s/fdef define-named-query
+  :args (s/alt :2-arity (s/cat :query-name     (every-pred keyword? namespace)
+                               :resolved-query some?)
+               :4-arity (s/cat :query-name     (every-pred keyword? namespace)
+                               :query-type     (s/alt :query-type pipeline/query-type?
+                                                      :default    #{:default})
+                               :model          some?
+                               :resolved-query some?))
+  :ret any?)

--- a/src/toucan2/tools/simple_out_transform.clj
+++ b/src/toucan2/tools/simple_out_transform.clj
@@ -1,0 +1,31 @@
+(ns toucan2.tools.simple-out-transform
+  (:require
+   [clojure.spec.alpha :as s]
+   [methodical.core :as m]
+   [toucan2.instance :as instance]
+   [toucan2.pipeline :as pipeline]))
+
+(defmacro define-out-transform
+  {:style/indent :defn}
+  [[query-type model-type] [instance-binding] & body]
+  `(m/defmethod pipeline/transduce-with-model :around [~query-type ~model-type]
+     [rf# ~'&query-type ~'&model ~'&parsed-args]
+     (let [rf*# ((map (fn [~instance-binding]
+                        (let [instance# (do ~@body)]
+                          (cond-> instance#
+                            (instance/instance? instance#)
+                            instance/reset-original))))
+                 rf#)]
+       (~'next-method rf*# ~'&query-type ~'&model ~'&parsed-args))))
+
+(s/fdef define-out-transform
+  :args (s/cat :dispatch-value (s/spec (s/cat :query-type keyword?
+                                              :model-type any?))
+               :bindings (s/spec (s/cat :row :clojure.core.specs.alpha/binding-form))
+               :body     (s/+ any?))
+  :ret any?)
+
+(comment
+  (define-out-transform [:toucan.query-type/select.instances ::venues]
+    [row]
+    (assoc row :neat true)))

--- a/src/toucan2/tools/transformed.clj
+++ b/src/toucan2/tools/transformed.clj
@@ -238,10 +238,9 @@
                     (xform v)
                     v))])))
 
-(m/defmethod query/build :before [#_query-type :toucan.query-type/update.*
-                                  #_model      ::transformed.model
-                                  #_query      :default]
-  [_query-type model {:keys [changes], :as parsed-args}]
+(m/defmethod pipeline/transduce-with-model :before [#_query-type :toucan.query-type/update.*
+                                                    #_model      ::transformed.model]
+  [_rf _query-type model {:keys [changes], :as parsed-args}]
   (b/cond
     (not (map? changes))
     parsed-args

--- a/src/toucan2/tools/transformed.clj
+++ b/src/toucan2/tools/transformed.clj
@@ -217,7 +217,7 @@
                  (f row))))))
     identity))
 
-(m/defmethod pipeline/transduce-with-model* [#_query-type :toucan.result-type/instances
+(m/defmethod pipeline/transduce-with-model [#_query-type :toucan.result-type/instances
                                              #_model      ::transformed.model]
   [rf query-type model parsed-args]
   ;; don't try to transform stuff when we're doing SELECT directly with PKs (e.g. to fake INSERT returning instances),
@@ -270,7 +270,7 @@
         row-xform  (apply comp row-xforms)]
     (map row-xform rows)))
 
-(m/defmethod pipeline/transduce-with-model* :before [#_query-type :toucan.query-type/insert.*
+(m/defmethod pipeline/transduce-with-model :before [#_query-type :toucan.query-type/insert.*
                                                      #_model      ::transformed.model]
   [_rf query-type model parsed-args]
   (assert (isa? model ::transformed.model))
@@ -295,8 +295,8 @@
 
 ;;;; after insert
 
-(m/defmethod pipeline/transduce-with-model* [#_query-type :toucan.query-type/insert.pks
-                                             #_model      ::transformed.model]
+(m/defmethod pipeline/transduce-with-model [#_query-type :toucan.query-type/insert.pks
+                                            #_model      ::transformed.model]
   [rf query-type model parsed-args]
   (let [pk-keys (model/primary-keys model)
         rf*     ((comp

--- a/src/toucan2/update.clj
+++ b/src/toucan2/update.clj
@@ -25,12 +25,17 @@
   [_query-type]
   ::default-args)
 
-(m/defmethod query/parse-args :toucan.query-type/update.*
+(defn parse-update-args
   [query-type unparsed-args]
-  (let [parsed (next-method query-type unparsed-args)]
+  (let [parsed (query/parse-args query-type unparsed-args)]
     (cond-> parsed
       (contains? parsed :pk) (-> (dissoc :pk)
                                  (update :kv-args assoc :toucan/pk (:pk parsed))))))
+
+(m/defmethod pipeline/transduce-unparsed :toucan.query-type/update.*
+  [rf query-type unparsed-args]
+  (let [parsed-args (parse-update-args query-type unparsed-args)]
+    (pipeline/transduce-parsed-args rf query-type parsed-args)))
 
 (m/defmethod query/build [:toucan.query-type/update.* :default clojure.lang.IPersistentMap]
   [query-type model {:keys [kv-args query changes], :as parsed-args}]

--- a/src/toucan2/update.clj
+++ b/src/toucan2/update.clj
@@ -9,7 +9,7 @@
 
 ;;; this is basically the same as the args for `select` and `delete` but the difference is that it has an additional
 ;;; optional arg, `:pk`, as the second arg, and one additional optional arg, the `changes` map at the end
-(s/def ::default-args
+(s/def ::args
   (s/cat
    :modelable ::query/default-args.modelable
    :pk        (s/? (complement (some-fn keyword? map?)))
@@ -21,13 +21,9 @@
    ;; here.
    :changes map?))
 
-(m/defmethod query/args-spec :toucan.query-type/update.*
-  [_query-type]
-  ::default-args)
-
 (defn parse-update-args
   [query-type unparsed-args]
-  (let [parsed (query/parse-args query-type unparsed-args)]
+  (let [parsed (query/parse-args query-type ::args unparsed-args)]
     (cond-> parsed
       (contains? parsed :pk) (-> (dissoc :pk)
                                  (update :kv-args assoc :toucan/pk (:pk parsed))))))

--- a/src/toucan2/update.clj
+++ b/src/toucan2/update.clj
@@ -43,9 +43,9 @@
                                      :set    changes})]
     (next-method query-type model parsed-args)))
 
-(m/defmethod pipeline/transduce-resolved-query* [#_query-type :toucan.query-type/update.*
-                                                 #_model      :default
-                                                 #_query      :default]
+(m/defmethod pipeline/transduce-resolved-query [#_query-type :toucan.query-type/update.*
+                                                #_model      :default
+                                                #_query      :default]
   [rf query-type model {:keys [changes], :as parsed-args} resolved-query]
   (if (empty? changes)
     (do
@@ -62,7 +62,7 @@
 (defn update!
   {:arglists '([modelable pk? conditions-map-or-query? & conditions-kv-args changes-map])}
   [& unparsed-args]
-  (pipeline/transduce-unparsed :toucan.query-type/update.update-count unparsed-args))
+  (pipeline/transduce-unparsed-with-default-rf :toucan.query-type/update.update-count unparsed-args))
 
 (defn reducible-update-returning-pks
   {:arglists '([modelable pk? conditions-map-or-query? & conditions-kv-args changes-map])}
@@ -72,6 +72,6 @@
 (defn update-returning-pks!
   {:arglists '([modelable pk? conditions-map-or-query? & conditions-kv-args changes-map])}
   [& unparsed-args]
-  (pipeline/transduce-unparsed :toucan.query-type/update.pks unparsed-args))
+  (pipeline/transduce-unparsed-with-default-rf :toucan.query-type/update.pks unparsed-args))
 
 ;;; TODO -- add `update-returning-instances!`, similar to [[toucan2.update/insert-returning-instances!]]

--- a/src/toucan2/util.clj
+++ b/src/toucan2/util.clj
@@ -245,6 +245,8 @@
   (safe-printable [^clojure.core.Eduction ed]
     (walk-safe-printable (list 'eduction (.xform ed) (.coll ed)))))
 
+;;;; [[try-with-error-context]]
+
 (defprotocol ^:private AddContext
   (^:no-doc add-context ^Throwable [^Throwable e additional-context]))
 
@@ -294,7 +296,9 @@
   [additional-context & body]
   `(try
      ~@body
-     (catch Throwable e#
+     (catch Exception e#
+       (throw (add-context e# ~additional-context)))
+     (catch AssertionError e#
        (throw (add-context e# ~additional-context)))))
 
 (s/fdef try-with-error-context

--- a/test/toucan2/delete_test.clj
+++ b/test/toucan2/delete_test.clj
@@ -75,7 +75,7 @@
                resolved-query))
         (is (= {:delete-from [:venues]
                 :where       [:= :id nil]}
-               (query/build :toucan.query-type/delete.update-count ::test/venues (assoc parsed-args :query resolved-query))))
+               (pipeline/build :toucan.query-type/delete.update-count ::test/venues parsed-args resolved-query)))
         (is (= ["DELETE FROM venues WHERE id IS NULL"]
                (tools.compile/compile
                  (delete/delete! ::test/venues nil))))))

--- a/test/toucan2/delete_test.clj
+++ b/test/toucan2/delete_test.clj
@@ -4,6 +4,7 @@
    [methodical.core :as m]
    [toucan2.delete :as delete]
    [toucan2.model :as model]
+   [toucan2.pipeline :as pipeline]
    [toucan2.query :as query]
    [toucan2.select :as select]
    [toucan2.test :as test]
@@ -69,12 +70,12 @@
     (let [parsed-args (query/parse-args :toucan.query-type/delete.update-count [::test/venues nil])]
       (is (= {:modelable ::test/venues, :queryable nil}
              parsed-args))
-      (query/with-resolved-query [query [::test/venues (:queryable parsed-args)]]
+      (let [resolved-query (pipeline/resolve-query :toucan.query-type/delete.update-count ::test/venues (:queryable parsed-args))]
         (is (= nil
-               query))
+               resolved-query))
         (is (= {:delete-from [:venues]
                 :where       [:= :id nil]}
-               (query/build :toucan.query-type/delete.update-count ::test/venues (assoc parsed-args :query query))))
+               (query/build :toucan.query-type/delete.update-count ::test/venues (assoc parsed-args :query resolved-query))))
         (is (= ["DELETE FROM venues WHERE id IS NULL"]
                (tools.compile/compile
                  (delete/delete! ::test/venues nil))))))

--- a/test/toucan2/execute_test.clj
+++ b/test/toucan2/execute_test.clj
@@ -6,9 +6,9 @@
    [toucan2.execute :as execute]
    [toucan2.instance :as instance]
    [toucan2.pipeline :as pipeline]
-   [toucan2.query :as query]
    [toucan2.realize :as realize]
-   [toucan2.test :as test])
+   [toucan2.test :as test]
+   [toucan2.tools.named-query :as tools.named-query])
   (:import
    (java.time LocalDateTime OffsetDateTime)))
 
@@ -85,9 +85,8 @@
       (is (= expected
              (execute/query ::test/db {:select [:id :created_at], :from [:venues], :order-by [[:id :asc]]}))))))
 
-(m/defmethod query/do-with-resolved-query [:default ::named-query]
-  [_model _query f]
-  (f ["SELECT count(*) AS \"count\" FROM people;"]))
+(tools.named-query/define-named-query ::named-query
+  ["SELECT count(*) AS \"count\" FROM people;"])
 
 (deftest query-test-2
   (is (= [{:count 4}]
@@ -101,7 +100,9 @@
             {:id 2, :name "Sam", :created-at (OffsetDateTime/parse "2019-01-11T23:56Z")}
             {:id 3, :name "Pam", :created-at (OffsetDateTime/parse "2020-01-01T21:56Z")}
             {:id 4, :name "Tam", :created-at (OffsetDateTime/parse "2020-05-25T19:56Z")}]
-           (execute/query ::test/db {:select [:*], :from [:people]}))))
+           (execute/query ::test/db {:select [:*], :from [:people]})))))
+
+(deftest execute-named-query-test
   (testing "named query"
     (is (= [{:count 4}]
            (execute/query ::test/db ::named-query)))))

--- a/test/toucan2/execute_test.clj
+++ b/test/toucan2/execute_test.clj
@@ -136,7 +136,7 @@
 ;;; as HoneySQL. There is currently no way to define custom compilation behavior on the basis of the connectable. Not
 ;;; sure how this would actually work tho without realizing the connection *first*; that causes its own problems because
 ;;; it breaks [[toucan2.tools.identity-execute/identity-query]]
-(m/defmethod pipeline/transduce-compiled-query-with-connection* [#_connection ::connectable.not-even-jdbc
+(m/defmethod pipeline/transduce-compiled-query-with-connection [#_connection ::connectable.not-even-jdbc
                                                                  #_query-type :default
                                                                  #_model      :default]
   [rf _conn _query-type _model [{k :key}, :as _compiled-query]]
@@ -146,16 +146,16 @@
   (is (= [{:a 1} {:a 2} {:a 3}]
          (execute/query ::connectable.not-even-jdbc [{:key :a}]))))
 
-(m/defmethod pipeline/transduce-with-model* [:default ::model.not-even-jdbc]
+(m/defmethod pipeline/transduce-with-model [:default ::model.not-even-jdbc]
   [rf query-type model {:keys [queryable], :as _parsed-args}]
   (pipeline/transduce-compiled-query rf query-type model queryable))
 
 ;;; here's how you can have custom compilation behavior. At this point in time it requires specifying a model as well
 ;;; since connection isn't realized until after the query compilation stage.
 
-(m/defmethod pipeline/transduce-compiled-query-with-connection* [#_connection ::connectable.not-even-jdbc
-                                                                 #_query-type :default
-                                                                 #_model      ::model.not-even-jdbc]
+(m/defmethod pipeline/transduce-compiled-query-with-connection [#_connection ::connectable.not-even-jdbc
+                                                                #_query-type :default
+                                                                #_model      ::model.not-even-jdbc]
   [rf _conn _query-type _model {k :key, :as _compiled-query}]
   (reduce rf (rf) [{k 4} {k 5} {k 6}]))
 

--- a/test/toucan2/insert_test.clj
+++ b/test/toucan2/insert_test.clj
@@ -6,7 +6,7 @@
    [toucan2.insert :as insert]
    [toucan2.instance :as instance]
    [toucan2.model :as model]
-   [toucan2.query :as query]
+   [toucan2.pipeline :as pipeline]
    [toucan2.select :as select]
    [toucan2.test :as test]
    [toucan2.tools.compile :as tools.compile]
@@ -58,10 +58,10 @@
 (deftest build-query-test
   (doseq [rows-fn [list vector]
           :let    [rows (rows-fn {:name "Grant & Green", :category "bar"})]]
-    (testing (pr-str (list `query/build :toucan.query-type/insert.* ::test/venues rows))
+    (testing (pr-str (list 'build :toucan.query-type/insert.* ::test/venues rows))
       (is (= {:insert-into [:venues]
               :values      [{:name "Grant & Green", :category "bar"}]}
-             (query/build :toucan.query-type/insert.* ::test/venues {:rows rows, :query {}}))))))
+             (pipeline/build :toucan.query-type/insert.* ::test/venues {:rows rows} {}))))))
 
 ;;; TODO -- a bit of a misnomer now.
 (defn- do-both-types-of-insert [f]

--- a/test/toucan2/insert_test.clj
+++ b/test/toucan2/insert_test.clj
@@ -22,37 +22,37 @@
 (deftest parse-args-test
   (testing "single map row"
     (is (= {:modelable :model, :rows [{:row 1}]}
-           (query/parse-args :toucan.query-type/insert.* [:model {:row 1}]))))
+           (insert/parse-insert-args :toucan.query-type/insert.* [:model {:row 1}]))))
   (testing "multiple map rows"
     (is (= {:modelable :model, :rows [{:row 1} {:row 2}]}
-           (query/parse-args :toucan.query-type/insert.* [:model [{:row 1} {:row 2}]]))))
+           (insert/parse-insert-args :toucan.query-type/insert.* [:model [{:row 1} {:row 2}]]))))
   (testing "kv args"
     (is (= {:modelable :model, :rows [{:a 1, :b 2, :c 3}]}
-           (query/parse-args :toucan.query-type/insert.* [:model :a 1, :b 2, :c 3])))
+           (insert/parse-insert-args :toucan.query-type/insert.* [:model :a 1, :b 2, :c 3])))
     (is (thrown-with-msg?
          clojure.lang.ExceptionInfo
          #"Don't know how to interpret :toucan.query-type/insert\.\* args:"
-         (query/parse-args :toucan.query-type/insert.* [:model :a 1, :b 2, :c]))))
+         (insert/parse-insert-args :toucan.query-type/insert.* [:model :a 1, :b 2, :c]))))
   (testing "columns + vector rows"
     (is (= {:modelable :model
             :rows      [{:a 1, :b 2, :c 3} {:a 4, :b 5, :c 6}]}
-           (query/parse-args :toucan.query-type/insert.* [:model [:a :b :c] [[1 2 3] [4 5 6]]])))
+           (insert/parse-insert-args :toucan.query-type/insert.* [:model [:a :b :c] [[1 2 3] [4 5 6]]])))
     (is (= {:modelable :model
             :rows      [{:name "The Ramp", :category "bar"}
                         {:name "Louie's", :category "bar"}]}
-           (query/parse-args :toucan.query-type/insert.* [:model [:name :category] [["The Ramp" "bar"] ["Louie's" "bar"]]]))))
+           (insert/parse-insert-args :toucan.query-type/insert.* [:model [:name :category] [["The Ramp" "bar"] ["Louie's" "bar"]]]))))
   (testing "nil"
     (is (= {:modelable :model, :rows nil}
-           (query/parse-args :toucan.query-type/insert.* [:model nil]))))
+           (insert/parse-insert-args :toucan.query-type/insert.* [:model nil]))))
   (testing "empty rows"
     (is (= {:modelable :model, :rows []}
-           (query/parse-args :toucan.query-type/insert.* [:model []]))))
+           (insert/parse-insert-args :toucan.query-type/insert.* [:model []]))))
   (testing "queryable"
     (is (= {:modelable :model, :queryable ::named-rows}
-           (query/parse-args :toucan.query-type/insert.* [:model ::named-rows]))))
+           (insert/parse-insert-args :toucan.query-type/insert.* [:model ::named-rows]))))
   (testing "record type"
     (is (= {:modelable :model, :rows [(->MyRecordType 1)]}
-           (query/parse-args :toucan.query-type/insert.* [:model (->MyRecordType 1)])))))
+           (insert/parse-insert-args :toucan.query-type/insert.* [:model (->MyRecordType 1)])))))
 
 (deftest build-query-test
   (doseq [rows-fn [list vector]

--- a/test/toucan2/insert_test.clj
+++ b/test/toucan2/insert_test.clj
@@ -9,7 +9,8 @@
    [toucan2.query :as query]
    [toucan2.select :as select]
    [toucan2.test :as test]
-   [toucan2.tools.compile :as tools.compile])
+   [toucan2.tools.compile :as tools.compile]
+   [toucan2.tools.named-query :as tools.named-query])
   (:import
    (java.time LocalDateTime)))
 
@@ -234,10 +235,9 @@
             (is (= 0
                    (call-count)))))))))
 
-(m/defmethod query/do-with-resolved-query [:default ::named-rows]
-  [_model _queryable f]
-  (f {:rows [{:name "Grant & Green", :category "bar"}
-             {:name "North Beach Cantina", :category "restaurant"}]}))
+(tools.named-query/define-named-query ::named-rows
+  {:rows [{:name "Grant & Green", :category "bar"}
+          {:name "North Beach Cantina", :category "restaurant"}]})
 
 (deftest named-query-test
   (doseq [insert! [#'insert/insert!

--- a/test/toucan2/no_jdbc_poc_test.clj
+++ b/test/toucan2/no_jdbc_poc_test.clj
@@ -7,7 +7,7 @@
 
 (set! *warn-on-reflection* true)
 
-(m/defmethod pipeline/transduce-with-model* [:default ::system-properties]
+(m/defmethod pipeline/transduce-with-model [:default ::system-properties]
   [rf _query-type _model {:keys [queryable kv-args]}]
   (let [ks (into (if (keyword? queryable) [queryable] [])
                  (mapcat identity)

--- a/test/toucan2/query_test.clj
+++ b/test/toucan2/query_test.clj
@@ -29,22 +29,6 @@
     :id [:in [1 2]]    [:in :id [1 2]]
     :id nil            [:= :id nil]))
 
-(m/defmethod query/do-with-resolved-query [:default ::named-query]
-  [_model _queryable f]
-  (f {:select [[:%count.* :count]], :from [:venues]}))
-
-(deftest with-resolved-query-test
-  (let [executed-body? (atom false)]
-    (query/with-resolved-query [resolved-query [nil ::named-query]]
-      (reset! executed-body? true)
-      (is (= {:select [[:%count.* :count]], :from [:venues]}
-             resolved-query)))
-    (is @executed-body?))
-  (testing "detect errors"
-    (is (thrown?
-         clojure.lang.Compiler$CompilerException
-         (macroexpand-1 `(query/with-resolved-query ~'resolved-query ::named-query))))))
-
 (deftest build-test
   (is (= {:where [:= :a 1]}
          (query/build ::my-query-type nil {:query {}, :kv-args {:a 1}}))))

--- a/test/toucan2/select_test.clj
+++ b/test/toucan2/select_test.clj
@@ -180,12 +180,12 @@
 
 (derive ::people.no-timestamps ::people)
 
-(m/defmethod pipeline/transduce-with-model* :before [:toucan.query-type/select.* ::people.no-timestamps]
+(m/defmethod pipeline/transduce-with-model :before [:toucan.query-type/select.* ::people.no-timestamps]
   [_rf _query-type _model parsed-args]
   (update parsed-args :columns (fn [columns]
                                  (or columns [:id :name]))))
 
-(m/defmethod pipeline/transduce-with-model* [:toucan.query-type/select.instances ::people.no-timestamps]
+(m/defmethod pipeline/transduce-with-model [:toucan.query-type/select.instances ::people.no-timestamps]
   [rf query-type model parsed-args]
   (let [rf* ((map (fn [person]
                     (testing "select* :after should see Toucan 2 instances"
@@ -215,7 +215,7 @@
 ;; TODO this is probably not the way you'd want to accomplish this in real life -- I think you'd probably actually want
 ;; to implement [[toucan2.query/build]] instead. But it does do a good job of letting us test that combining aux methods
 ;; work like we'd expect.
-(m/defmethod pipeline/transduce-built-query* :before [:toucan.query-type/select.* ::people.limit-2 clojure.lang.IPersistentMap]
+(m/defmethod pipeline/transduce-built-query :before [:toucan.query-type/select.* ::people.limit-2 clojure.lang.IPersistentMap]
   [_rf _query-type _model built-query]
   (assoc built-query :limit 2))
 

--- a/test/toucan2/select_test.clj
+++ b/test/toucan2/select_test.clj
@@ -43,29 +43,29 @@
 (deftest ^:parallel default-build-query-test
   (is (= {:select [:*]
           :from   [[:default]]}
-         (query/build :toucan.query-type/select.* :default {:query {}})))
+         (pipeline/build :toucan.query-type/select.* :default {} {})))
   (testing "don't override existing"
     (is (= {:select [:a :b]
             :from   [[:my_table]]}
-           (query/build :toucan.query-type/select.* :default {:query {:select [:a :b], :from [[:my_table]]}}))))
+           (pipeline/build :toucan.query-type/select.* :default {} {:select [:a :b], :from [[:my_table]]}))))
   (testing "columns"
     (is (= {:select [:a :b]
             :from   [[:default]]}
-           (query/build :toucan.query-type/select.* :default {:query {}, :columns [:a :b]})))
+           (pipeline/build :toucan.query-type/select.* :default {:columns [:a :b]} {})))
     (testing "existing"
       (is (= {:select [:a]
               :from   [[:default]]}
-             (query/build :toucan.query-type/select.* :default {:query {:select [:a]}, :columns [:a :b]})))))
+             (pipeline/build :toucan.query-type/select.* :default {:columns [:a :b]} {:select [:a]})))))
   (testing "conditions"
     (is (= {:select [:*]
             :from   [[:default]]
             :where  [:= :id 1]}
-           (query/build :toucan.query-type/select.* :default {:query {}, :kv-args {:id 1}})))
+           (pipeline/build :toucan.query-type/select.* :default {:kv-args {:id 1}} {})))
     (testing "merge with existing"
       (is (= {:select [:*]
               :from   [[:default]]
               :where  [:and [:= :a :b] [:= :id 1]]}
-             (query/build :toucan.query-type/select.* :default {:query {:where [:= :a :b]}, :kv-args {:id 1}}))))))
+             (pipeline/build :toucan.query-type/select.* :default {:kv-args {:id 1}} {:where [:= :a :b]}))))))
 
 (m/defmethod query/apply-kv-arg [:default clojure.lang.IPersistentMap ::custom.limit]
   [_model honeysql-form _k limit]
@@ -75,16 +75,16 @@
   (is (= {:select [:*]
           :from   [[:default]]
           :limit  100}
-         (query/build :toucan.query-type/select.* :default {:query {}, :kv-args {::custom.limit 100}})
-         (query/build :toucan.query-type/select.* :default {:query {:limit 1}, :kv-args {::custom.limit 100}}))))
+         (pipeline/build :toucan.query-type/select.* :default {:kv-args {::custom.limit 100}} {})
+         (pipeline/build :toucan.query-type/select.* :default {:kv-args {::custom.limit 100}} {:limit 1}))))
 
 (deftest built-in-pk-condition-test
   (is (= {:select [:*], :from [[:default]], :where [:= :id 1]}
-         (query/build :toucan.query-type/select.* :default {:query {}, :kv-args {:toucan/pk 1}})))
+         (pipeline/build :toucan.query-type/select.* :default {:kv-args {:toucan/pk 1}} {})))
   (is (= {:select [:*], :from [[:default]], :where [:and
                                                     [:= :name "Cam"]
                                                     [:= :id 1]]}
-         (query/build :toucan.query-type/select.* :default {:query {:where [:= :name "Cam"]}, :kv-args {:toucan/pk 1}}))))
+         (pipeline/build :toucan.query-type/select.* :default {:kv-args {:toucan/pk 1}} {:where [:= :name "Cam"]}))))
 
 (deftest select-test
   (let [expected [(instance/instance ::test/people {:id 1, :name "Cam", :created-at (OffsetDateTime/parse "2020-04-21T23:56Z")})]]
@@ -211,8 +211,8 @@
 (derive ::people.limit-2 ::people)
 
 ;; TODO this is probably not the way you'd want to accomplish this in real life -- I think you'd probably actually want
-;; to implement [[toucan2.query/build]] instead. But it does do a good job of letting us test that combining aux methods
-;; work like we'd expect.
+;; to implement [[toucan2.pipeline/build]] instead. But it does do a good job of letting us test that combining aux
+;; methods work like we'd expect.
 (m/defmethod pipeline/transduce-built-query :before [:toucan.query-type/select.* ::people.limit-2 clojure.lang.IPersistentMap]
   [_rf _query-type _model built-query]
   (assoc built-query :limit 2))
@@ -376,7 +376,7 @@
         (is (= nil
                query))
         (is (= {:select [:*], :from [[:venues]], :where [:= :id nil]}
-               (query/build :toucan.query-type/select.* ::test/venues (assoc parsed-args :query query))))))
+               (pipeline/build :toucan.query-type/select.* ::test/venues parsed-args query)))))
     (is (= ["SELECT * FROM venues WHERE id IS NULL"]
            (tools.compile/compile
              (select/select ::test/venues nil))))
@@ -403,17 +403,18 @@
 
 (derive ::venues.with-category ::test/venues)
 
-(m/defmethod query/build :after [#_query-type :toucan.query-type/select.*
-                                 #_model      ::venues.with-category
-                                 #_query      clojure.lang.IPersistentMap]
-  [_query-type model built-query]
+(m/defmethod pipeline/transduce-resolved-query [#_query-type :toucan.query-type/select.*
+                                                #_model      ::venues.with-category
+                                                #_query      clojure.lang.IPersistentMap]
+  [rf query-type model parsed-args resolved-query]
   (let [model-ns-str    (some-> (model/namespace model) name)
         venues-category (keyword
                          (str
                           (when model-ns-str
                             (str model-ns-str \.))
-                          "category"))]
-    (assoc built-query :left-join [:category [:= venues-category :category.name]])))
+                          "category"))
+        resolved-query  (assoc resolved-query :left-join [:category [:= venues-category :category.name]])]
+    (next-method rf query-type model parsed-args resolved-query)))
 
 (deftest joined-model-test
   (is (= (instance/instance ::venues.with-category

--- a/test/toucan2/tools/before_delete_test.clj
+++ b/test/toucan2/tools/before_delete_test.clj
@@ -2,13 +2,12 @@
   (:require
    [clojure.test :refer :all]
    [toucan2.delete :as delete]
+   [toucan2.execute :as execute]
    [toucan2.instance :as instance]
    [toucan2.select :as select]
    [toucan2.test :as test]
    [toucan2.tools.before-delete :as before-delete]
-   [toucan2.update :as update]
-   [toucan2.pipeline :as pipeline]
-   [toucan2.execute :as execute])
+   [toucan2.update :as update])
   (:import
    (java.time LocalDateTime)))
 

--- a/test/toucan2/tools/before_insert_test.clj
+++ b/test/toucan2/tools/before_insert_test.clj
@@ -3,13 +3,12 @@
    [clojure.edn :as edn]
    [clojure.string :as str]
    [clojure.test :refer :all]
-   [methodical.core :as m]
    [toucan2.insert :as insert]
    [toucan2.instance :as instance]
-   [toucan2.query :as query]
    [toucan2.select :as select]
    [toucan2.test :as test]
    [toucan2.tools.before-insert :as before-insert]
+   [toucan2.tools.named-query :as tools.named-query]
    [toucan2.tools.transformed :as transformed])
   (:import
    (java.time LocalDateTime)))
@@ -79,10 +78,9 @@
             (is (= expected
                    (select/select-one ::venues.serialized-category :id 4)))))))))
 
-(m/defmethod query/do-with-resolved-query [:default ::named-rows]
-  [_model _queryable f]
-  (f {:rows [{:name "Grant & Green", :category "bar"}
-             {:name "North Beach Cantina", :category "restaurant"}]}))
+(tools.named-query/define-named-query ::named-rows
+  {:rows [{:name "Grant & Green", :category "bar"}
+          {:name "North Beach Cantina", :category "restaurant"}]})
 
 (deftest named-query-test
   (doseq [insert! [#_#'insert/insert!

--- a/test/toucan2/tools/before_select_test.clj
+++ b/test/toucan2/tools/before_select_test.clj
@@ -22,8 +22,8 @@
 
 (deftest before-select-test
   (is (= (instance/instance ::people.id-and-name {:id             1
-                                      :name           "Cam"
-                                      ::after-select? true})
+                                                  :name           "Cam"
+                                                  ::after-select? true})
          (select/select-one ::people.id-and-name 1))))
 
 (derive ::people.named-cam ::test/people)

--- a/test/toucan2/tools/default_fields_test.clj
+++ b/test/toucan2/tools/default_fields_test.clj
@@ -3,7 +3,7 @@
    [clojure.test :refer :all]
    [toucan2.insert :as insert]
    [toucan2.instance :as instance]
-   [toucan2.query :as query]
+   [toucan2.pipeline :as pipeline]
    [toucan2.select :as select]
    [toucan2.test :as test]
    [toucan2.tools.default-fields :as default-fields]))
@@ -19,7 +19,7 @@
 
 (deftest select-test
   (is (= {:select [:id :name :category], :from [[:venues]]}
-         (query/build :toucan.query-type/select.instances ::venues.default-fields {:query {}})))
+         (pipeline/build :toucan.query-type/select.instances ::venues.default-fields {} {})))
   (is (= [(instance/instance ::venues.default-fields
                              {:id 1, :name "Tempest", :category "bar"})
           (instance/instance ::venues.default-fields
@@ -29,7 +29,7 @@
          (select/select ::venues.default-fields)))
   (testing "should still be able to override default fields"
       (is (= {:select [:id :name], :from [[:venues]]}
-             (query/build :toucan.query-type/select.* ::venues.default-fields {:query {}, :columns [:id :name]})))
+             (pipeline/build :toucan.query-type/select.* ::venues.default-fields {:columns [:id :name]} {})))
       (is (= (instance/instance ::venues.default-fields
                                 {:id 1, :name "Tempest"})
              (select/select-one [::venues.default-fields :id :name] {:order-by [[:id :asc]]})))))

--- a/test/toucan2/tools/identity_query_test.clj
+++ b/test/toucan2/tools/identity_query_test.clj
@@ -1,15 +1,14 @@
 (ns toucan2.tools.identity-query-test
   (:require
    [clojure.test :refer :all]
-   [methodical.core :as m]
    [toucan2.execute :as execute]
    [toucan2.instance :as instance]
    [toucan2.pipeline :as pipeline]
-   [toucan2.query :as query]
    [toucan2.select :as select]
    [toucan2.test :as test]
    [toucan2.tools.after-select :as after-select]
-   [toucan2.tools.identity-query :as identity-query]))
+   [toucan2.tools.identity-query :as identity-query]
+   [toucan2.tools.named-query :as tools.named-query]))
 
 (deftest query-test
   (is (= [[1 2]
@@ -25,10 +24,9 @@
           (instance/instance ::parrot {:id 2, :name "Green Friend"})]
          (select/select ::parrot parrot-query))))
 
-(m/defmethod query/do-with-resolved-query [:default ::parrot-query]
-  [_model _queryable f]
-  (f (identity-query/identity-query [{:id 1, :name "Parroty"}
-                                     {:id 2, :name "Green Friend"}])))
+(tools.named-query/define-named-query ::parrot-query
+  (identity-query/identity-query [{:id 1, :name "Parroty"}
+                                  {:id 2, :name "Green Friend"}]))
 
 (deftest named-query-test
   (is (= [(instance/instance ::parrot {:id 1, :name "Parroty"})

--- a/test/toucan2/tools/transformed_test.clj
+++ b/test/toucan2/tools/transformed_test.clj
@@ -277,14 +277,14 @@
 (deftest transform-insert-returning-results-without-select-test
   (testing "insert-returning-instances results should be transformed if they come directly from the DB (not via select)"
     (test/with-discarded-table-changes :venues
-      (binding [pipeline/*transduce-resolved-query* (fn [rf _query-type _model {:keys [rows]} _resolved-query]
-                                                      {:pre [(seq? rows)]}
-                                                      (transduce identity rf (map (fn [row]
-                                                                                    (update row :category name))
-                                                                                  rows)))]
+      (binding [pipeline/transduce-resolved-query (fn [rf _query-type _model {:keys [rows]} _resolved-query]
+                                                    {:pre [(seq? rows)]}
+                                                    (transduce identity rf (map (fn [row]
+                                                                                  (update row :category name))
+                                                                                rows)))]
         (is (= (instance/instance ::venues.category-keyword
                                   {:name "BevLess", :category :bar})
-               (pipeline/transduce-with-model*
+               (pipeline/transduce-with-model
                 (completing conj first)
                 :toucan.query-type/insert.instances
                 ::venues.category-keyword

--- a/test/toucan2/tools/transformed_test.clj
+++ b/test/toucan2/tools/transformed_test.clj
@@ -8,7 +8,6 @@
    [toucan2.model :as model]
    [toucan2.pipeline :as pipeline]
    [toucan2.protocols :as protocols]
-   [toucan2.query :as query]
    [toucan2.save :as save]
    [toucan2.select :as select]
    [toucan2.test :as test]
@@ -294,11 +293,10 @@
                (select/count ::test/venues)))))))
 
 (deftest delete!-test
-  (testing `query/build
+  (testing `pipeline/build
     (is (= {:delete-from [:venues]
             :where       [:= :category "bar"]}
-           (query/build :toucan.query-type/delete.update-count ::venues.category-keyword {:kv-args {:category :bar}
-                                                                                          :query   {}}))))
+           (pipeline/build :toucan.query-type/delete.update-count ::venues.category-keyword {:kv-args {:category :bar}} {}))))
   (testing "Delete row by PK"
     (test/with-discarded-table-changes :venues
       (is (= 1

--- a/test/toucan2/update_test.clj
+++ b/test/toucan2/update_test.clj
@@ -18,19 +18,19 @@
 
 (deftest parse-update-args-test
   (is (= {:modelable :model, :changes {:a 1}, :kv-args {:toucan/pk 1}, :queryable {}}
-         (query/parse-args :toucan.query-type/update.* [:model 1 {:a 1}])))
+         (update/parse-update-args :toucan.query-type/update.* [:model 1 {:a 1}])))
   (is (= {:modelable :model, :changes {:a 1}, :kv-args {:toucan/pk nil}, :queryable {}}
-         (query/parse-args :toucan.query-type/update.* [:model nil {:a 1}])))
+         (update/parse-update-args :toucan.query-type/update.* [:model nil {:a 1}])))
   (is (= {:modelable :model, :kv-args {:id 1}, :changes {:a 1}, :queryable {}}
-         (query/parse-args :toucan.query-type/update.* [:model :id 1 {:a 1}])))
+         (update/parse-update-args :toucan.query-type/update.* [:model :id 1 {:a 1}])))
   (testing "composite PK"
     (is (= {:modelable :model, :changes {:a 1}, :kv-args {:toucan/pk [1 2]}, :queryable {}}
-           (query/parse-args :toucan.query-type/update.* [:model [1 2] {:a 1}]))))
+           (update/parse-update-args :toucan.query-type/update.* [:model [1 2] {:a 1}]))))
   (testing "key-value conditions"
     (is (= {:modelable :model, :kv-args {:name "Cam", :toucan/pk 1}, :changes {:a 1}, :queryable {}}
-           (query/parse-args :toucan.query-type/update.* [:model 1 :name "Cam" {:a 1}]))))
+           (update/parse-update-args :toucan.query-type/update.* [:model 1 :name "Cam" {:a 1}]))))
   (is (= {:modelable :model, :changes {:name "Hi-Dive"}, :queryable {:id 1}}
-         (query/parse-args :toucan.query-type/update.* [:model {:id 1} {:name "Hi-Dive"}]))))
+         (update/parse-update-args :toucan.query-type/update.* [:model {:id 1} {:name "Hi-Dive"}]))))
 
 (deftest build-test
   (is (= {:update [:venues]
@@ -102,7 +102,7 @@
 
 (deftest update-nil-test
   (testing "(update! model nil ...) should basically be the same as (update! model :toucan/pk nil ...)"
-    (let [parsed-args (query/parse-args :toucan.query-type/update.* [::test/venues nil {:name "Taco Bell"}])]
+    (let [parsed-args (update/parse-update-args :toucan.query-type/update.* [::test/venues nil {:name "Taco Bell"}])]
       (is (= {:modelable ::test/venues
               :kv-args   {:toucan/pk nil}
               :changes   {:name "Taco Bell"}

--- a/test/toucan2/update_test.clj
+++ b/test/toucan2/update_test.clj
@@ -5,7 +5,6 @@
    [toucan2.instance :as instance]
    [toucan2.model :as model]
    [toucan2.pipeline :as pipeline]
-   [toucan2.query :as query]
    [toucan2.select :as select]
    [toucan2.test :as test]
    [toucan2.tools.compile :as tools.compile]
@@ -40,11 +39,11 @@
           :where  [:and
                    [:= :name "Tempest"]
                    [:= :id 1]]}
-         (query/build :toucan.query-type/update.*
-                      ::test/venues
-                      {:changes {:name "Hi-Dive"}
-                       :query   {:id 1}
-                       :kv-args {:name "Tempest"}}))))
+         (pipeline/build :toucan.query-type/update.*
+                         ::test/venues
+                         {:changes {:name "Hi-Dive"}
+                          :kv-args {:name "Tempest"}}
+                         {:id 1}))))
 
 (deftest pk-and-map-conditions-test
   (test/with-discarded-table-changes :venues
@@ -115,7 +114,7 @@
         (is (= {:update    [:venues]
                 :set       {:name "Taco Bell"}
                 :where     [:= :id nil]}
-               (query/build :toucan.query-type/update.* ::test/venues (assoc parsed-args :query query))))))
+               (pipeline/build :toucan.query-type/update.* ::test/venues parsed-args query)))))
     (is (= ["UPDATE venues SET name = ? WHERE id IS NULL" "Taco Bell"]
            (tools.compile/compile
              (update/update! ::test/venues nil {:name "Taco Bell"}))))

--- a/test/toucan2/update_test.clj
+++ b/test/toucan2/update_test.clj
@@ -4,10 +4,12 @@
    [methodical.core :as m]
    [toucan2.instance :as instance]
    [toucan2.model :as model]
+   [toucan2.pipeline :as pipeline]
    [toucan2.query :as query]
    [toucan2.select :as select]
    [toucan2.test :as test]
    [toucan2.tools.compile :as tools.compile]
+   [toucan2.tools.named-query :as tools.named-query]
    [toucan2.update :as update])
   (:import
    (java.time LocalDateTime)))
@@ -78,9 +80,8 @@
              (update/update! ::test/venues 1 {})
              (update/update! ::test/venues {}))))))
 
-(m/defmethod query/do-with-resolved-query [:default ::named-conditions]
-  [model _queryable f]
-  (query/do-with-resolved-query model {:id 1} f))
+(tools.named-query/define-named-query ::named-conditions
+  {:id 1})
 
 (deftest named-conditions-test
   (test/with-discarded-table-changes :venues
@@ -108,7 +109,7 @@
               :changes   {:name "Taco Bell"}
               :queryable {}}
              parsed-args))
-      (query/with-resolved-query [query [::test/venues (:queryable parsed-args)]]
+      (let [query (pipeline/resolve-query :toucan.query-type/update.* ::test/venues (:queryable parsed-args))]
         (is (= {}
                query))
         (is (= {:update    [:venues]

--- a/toucan1/src/toucan/models.clj
+++ b/toucan1/src/toucan/models.clj
@@ -321,10 +321,10 @@
 ;;   {:pre [(map? changes-map)]}
 ;;   (model/with-model [model modelable]
 ;;     (binding [
-;;               pipeline/*transduce-built-query* (fn [rf query-type model built-query]
+;;               pipeline/transduce-built-query (fn [rf query-type model built-query]
 ;;                                                  (println "built-query:" built-query) ; NOCOMMIT
 ;;                                                  (if (isa? query-type :toucan.query-type/select.*)
-;;                                                    (pipeline/transduce-built-query* rf query-type model built-query)
+;;                                                    (pipeline/transduce-built-query rf query-type model built-query)
 ;;                                                    (binding [conn/*current-connectable* (identity-query/identity-connection nil)]
 ;;                                                      built-query)))]
 ;;       (update/update! model nil changes-map))))
@@ -355,7 +355,7 @@
 ;;   ;; FIXME
 ;;   (let [model (protocols/model instance)]
 ;;     (binding [conn/*current-connectable*          (identity-query/identity-connection nil)
-;;               pipeline/*transduce-compiled-query* (fn [rf query-type model _compiled-query]
+;;               pipeline/transduce-compiled-query (fn [rf query-type model _compiled-query]
 ;;                                                     (if (isa? query-type :toucan.query-type/select.instances)
 ;;                                                       (transduce
 ;;                                                        (map (partial instance/instance model))


### PR DESCRIPTION
Follow-on refactor to simplify the query pipeline a bit more. Remove/consolidate several multimethods.