### PR TITLE
Fix transient maps with large number of keys; fix transient magic map `dissoc!` not transforming keys

### DIFF
--- a/src/toucan2/connection.clj
+++ b/src/toucan2/connection.clj
@@ -38,7 +38,7 @@
 
 
 (defmacro with-connection
-  {:arglists '([[connection-binding connectable] & body]
+  {:arglists '([[connection-binding]             & body]
                [[connection-binding connectable] & body])}
   [[connection-binding connectable] & body]
   `(do-with-connection

--- a/src/toucan2/instance.clj
+++ b/src/toucan2/instance.clj
@@ -44,16 +44,16 @@
     (get m k default-value))
 
   (assoc [this k v]
-    (let [new-m (assoc m k v)]
-      (if (identical? m new-m)
+    (let [m' (assoc m k v)]
+      (if (identical? m m')
         this
-        (Instance. model orig new-m mta))))
+        (Instance. model orig m' mta))))
 
   (dissoc [this k]
-    (let [new-m (dissoc m k)]
-      (if (identical? m new-m)
+    (let [m' (dissoc m k)]
+      (if (identical? m m')
         this
-        (Instance. model orig new-m mta))))
+        (Instance. model orig m' mta))))
 
   (keys [_this]
     (keys m))
@@ -147,23 +147,29 @@
       (if (identical? m m')
         this
         (TransientInstance. model m' mta))))
+
   (persistent [_this]
     (let [m (persistent! m)]
       (Instance. model m m mta)))
+
   (assoc [this k v]
     (let [m' (assoc! m k v)]
       (if (identical? m m')
         this
         (TransientInstance. model m' mta))))
+
   (without [this k]
     (let [m' (dissoc! m k)]
       (if (identical? m m')
         this
         (TransientInstance. model m' mta))))
+
   (valAt [_this k]
     (.valAt m k))
+
   (valAt [_this k not-found]
     (.valAt m k not-found))
+
   (count [_this]
     (count m))
 

--- a/src/toucan2/instance.clj
+++ b/src/toucan2/instance.clj
@@ -143,17 +143,23 @@
 (deftype ^:no-doc TransientInstance [model ^clojure.lang.ITransientMap m mta]
   clojure.lang.ITransientMap
   (conj [this v]
-    (.conj m v)
-    this)
+    (let [m' (conj! m v)]
+      (if (identical? m m')
+        this
+        (TransientInstance. model m' mta))))
   (persistent [_this]
     (let [m (persistent! m)]
       (Instance. model m m mta)))
   (assoc [this k v]
-    (.assoc m k v)
-    this)
+    (let [m' (assoc! m k v)]
+      (if (identical? m m')
+        this
+        (TransientInstance. model m' mta))))
   (without [this k]
-    (.without m k)
-    this)
+    (let [m' (dissoc! m k)]
+      (if (identical? m m')
+        this
+        (TransientInstance. model m' mta))))
   (valAt [_this k]
     (.valAt m k))
   (valAt [_this k not-found]

--- a/src/toucan2/jdbc/read.clj
+++ b/src/toucan2/jdbc/read.clj
@@ -161,7 +161,7 @@
 
 ;;; TODO -- why is cljdoc picking this up?
 (when-let [pg-connection-class (try
-                                 (Class/forName "org.postgresql.jdbc.PgConnection")
+                                 (Class/forName "org.postgresql.jdbc.PgConnection") ; TODO -- or is this `org.postgresql.PGConnection`
                                  (catch Throwable _
                                    nil))]
   (m/defmethod read-column-thunk [pg-connection-class :default Types/TIMESTAMP]

--- a/src/toucan2/jdbc/result_set.clj
+++ b/src/toucan2/jdbc/result_set.clj
@@ -25,17 +25,21 @@
   (->row [_this]
     (log/tracef :results "Fetching row %s" (.getRow rset))
     (transient (instance/instance model)))
+
   (column-count [_this]
     (count cols))
+
   ;; this is purposefully not implemented because we should never get here; if we do it is an error and we want an
   ;; Exception thrown.
   #_(with-column [this row i]
       (println (pr-str (list 'with-column 'this 'row i)))
       (next.jdbc.rs/with-column-value this row (nth cols (dec i))
         (next.jdbc.rs/read-column-by-index (.getObject rset ^Integer i) rsmeta i)))
+
   (with-column-value [_this row col v]
     (assert (some? col) "Invalid col")
     (assoc! row col v))
+
   (row! [_this row]
     (log/tracef :results "Converting transient row to persistent row")
     (persistent! row))
@@ -43,8 +47,10 @@
   next.jdbc.rs/ResultSetBuilder
   (->rs [_this]
     (transient []))
+
   (with-row [_this acc row]
     (conj! acc row))
+
   (rs! [_this acc]
     (persistent! acc)))
 

--- a/src/toucan2/magic_map.clj
+++ b/src/toucan2/magic_map.clj
@@ -50,16 +50,16 @@
     (get m (key-xform k) default-value))
 
   (assoc [this k v]
-    (let [new-m (assoc m (key-xform k) v)]
-      (if (identical? m new-m)
+    (let [m' (assoc m (key-xform k) v)]
+      (if (identical? m m')
         this
-        (MagicMap. new-m key-xform mta))))
+        (MagicMap. m' key-xform mta))))
 
   (dissoc [this k]
-    (let [new-m (dissoc m (key-xform k))]
-      (if (identical? m new-m)
+    (let [m' (dissoc m (key-xform k))]
+      (if (identical? m m')
         this
-        (MagicMap. new-m key-xform mta))))
+        (MagicMap. m' key-xform mta))))
 
   (keys [_this]
     (keys m))
@@ -101,17 +101,23 @@
 (deftype ^:no-doc TransientMagicMap [^clojure.lang.ITransientMap m key-xform mta]
   clojure.lang.ITransientMap
   (conj [this [k v]]
-    (.conj m [(key-xform k) v])
-    this)
+    (let [m' (conj! m [(key-xform k) v])]
+      (if (identical? m m')
+        this
+        (TransientMagicMap. m' key-xform mta))))
   (persistent [_this]
     (let [m (persistent! m)]
       (MagicMap. m key-xform mta)))
   (assoc [this k v]
-    (.assoc m (key-xform k) v)
-    this)
+    (let [m' (assoc! m (key-xform k) v)]
+      (if (identical? m m')
+        this
+        (TransientMagicMap. m' key-xform mta))))
   (without [this k]
-    (.without m (key-xform k))
-    this)
+    (let [m' (dissoc! m k)]
+      (if (identical? m m')
+        this
+        (TransientMagicMap. m' key-xform mta))))
   (valAt [this k]
     (.valAt this k nil))
   (valAt [_this k not-found]

--- a/src/toucan2/magic_map.clj
+++ b/src/toucan2/magic_map.clj
@@ -105,23 +105,29 @@
       (if (identical? m m')
         this
         (TransientMagicMap. m' key-xform mta))))
+
   (persistent [_this]
     (let [m (persistent! m)]
       (MagicMap. m key-xform mta)))
+
   (assoc [this k v]
     (let [m' (assoc! m (key-xform k) v)]
       (if (identical? m m')
         this
         (TransientMagicMap. m' key-xform mta))))
+
   (without [this k]
-    (let [m' (dissoc! m k)]
+    (let [m' (dissoc! m (key-xform k))]
       (if (identical? m m')
         this
         (TransientMagicMap. m' key-xform mta))))
+
   (valAt [this k]
     (.valAt this k nil))
+
   (valAt [_this k not-found]
     (.valAt m (key-xform k) not-found))
+
   (count [_this]
     (count m))
 

--- a/src/toucan2/tools/with_temp.clj
+++ b/src/toucan2/tools/with_temp.clj
@@ -26,7 +26,7 @@
 
   ```clj
   (m/defmethod do-with-temp* :before :default
-    [model attributes f]
+    [_model _explicit-attributes f]
     (set-up-db!)
     f)
   ```
@@ -37,7 +37,7 @@
   ```clj
   (merge {} (with-temp-defaults model) explict-attributes)
   ```"
-  {:arglists '([model explicit-attributes f])}
+  {:arglists '([model₁ explicit-attributes f])}
   u/dispatch-on-first-arg)
 
 (m/defmethod do-with-temp* :default

--- a/test/toucan2/instance_test.clj
+++ b/test/toucan2/instance_test.clj
@@ -379,3 +379,24 @@
   (let [m1 (instance/instance ::birbs {:a 1})
         m2 (instance/instance ::birbs m1)]
     (is (identical? m1 m2))))
+
+(deftest ^:parallel lots-of-keys-test
+  (testing "Make sure things still work when we pass the threshold from ArrayMap -> HashMap"
+    (let [m {:date_joined   :%now
+             :email         "nobody@nowhere.com"
+             :first_name    "No"
+             :is_active     true
+             :is_superuser  false
+             :last_login    nil
+             :last_name     "Body"
+             :password      "$2a$10$B/Cu7Nva.Ad.0gtu5g3o7udSbBl2r4YG.jRnxvIUWuNzmO7LCu2Cy"
+             :password_salt "c4467d75-59d2-41a5-9499-e6c5d8db923b"
+             :updated_at    :%now}]
+      (testing `instance/instance
+        (is (= m
+               (instance/instance
+                :models/User
+                m))))
+      (testing `into
+        (is (= m
+              (into (instance/instance :models/User) m)))))))

--- a/test/toucan2/magic_map_test.clj
+++ b/test/toucan2/magic_map_test.clj
@@ -226,3 +226,16 @@
         (is (= m
                (into (magic-map/magic-map {})
                      m)))))))
+
+(deftest ^:parallel transient-assoc-dissoc-test
+  (testing "Make sure transient `assoc!` and `dissoc!` do the right thing with keys that get transformed"
+    (let [m (reduce (fn [m n]
+                      (assoc! m (str n) n))
+                    (transient (magic-map/magic-map))
+                    (range 15))
+          m (reduce (fn [m n]
+                      (dissoc! m (str n)))
+                    m
+                    (range 15))]
+      (is (= {}
+             (persistent! m))))))

--- a/test/toucan2/magic_map_test.clj
+++ b/test/toucan2/magic_map_test.clj
@@ -204,3 +204,25 @@
     (instance/instance :venues)    false
     (magic-map/magic-map)          true
     (magic-map/magic-map {:a 100}) true))
+
+(deftest ^:parallel lots-of-keys-test
+  (testing "Make sure things still work when we pass the threshold from ArrayMap -> HashMap"
+    (let [m {:date_joined   :%now
+             :email         "nobody@nowhere.com"
+             :first_name    "No"
+             :is_active     true
+             :is_superuser  false
+             :last_login    nil
+             :last_name     "Body"
+             :password      "$2a$10$B/Cu7Nva.Ad.0gtu5g3o7udSbBl2r4YG.jRnxvIUWuNzmO7LCu2Cy"
+             :password_salt "c4467d75-59d2-41a5-9499-e6c5d8db923b"
+             :updated_at    :%now}]
+      (testing `magic-map/magic-map
+        (is (= m
+               (magic-map/magic-map
+                m
+                magic-map/kebab-case-xform))))
+      (testing `into
+        (is (= m
+               (into (magic-map/magic-map {})
+                     m)))))))

--- a/test/toucan2/tools/hydrate_test.clj
+++ b/test/toucan2/tools/hydrate_test.clj
@@ -556,7 +556,7 @@
   [venue]
   (hydrate/hydrate (assoc venue :person-id 1, :person-name "Cam") ::person))
 
-(deftest ^:parallel hydrate-in-after-select-test []
+(deftest ^:parallel hydrate-in-after-select-test
   (is (= {:id          1
           :person-id   1
           :person-name "Cam"

--- a/toucan1/src/toucan/models.clj
+++ b/toucan1/src/toucan/models.clj
@@ -246,7 +246,7 @@
                                     column->k)
         model                 (model/resolve-model modelable)]
     (transformed/deftransforms model
-        column->direction->fn)))
+      column->direction->fn)))
 
 (defn types
   "Get the transforms associated with a model. Returns map of `column name => direction => fn`."


### PR DESCRIPTION
Transient Instance maps and MagicMaps didn't correctly handle cases where the maps passed the ArrayMap -> HashMap threshold. They discarded the values of transient functions like `assoc!`. Fix bugs with creating instances/magic maps with large numbers of keys.

Also misc code cleanup and extra tests.