### PR TITLE
Check first non-nil key for sequence-of-sequence hydration

### DIFF
--- a/src/toucan2/tools/hydrate.clj
+++ b/src/toucan2/tools/hydrate.clj
@@ -629,7 +629,11 @@
          (empty? results))
     results
 
-    (sequential? (first results))
+    ;; check whether the first non-nil result is a sequence. If it is, then hydrate sequences-of-sequences
+    (sequential? (some (fn [result]
+                         (when (some? result)
+                           result))
+                       results))
     (hydrate-sequence-of-sequences model results k)
 
     (keyword? k)

--- a/test/toucan2/tools/hydrate_test.clj
+++ b/test/toucan2/tools/hydrate_test.clj
@@ -381,6 +381,28 @@
   (for [row rows]
     (assoc row ::is-bird? true)))
 
+(m/defmethod hydrate/batched-hydrate [:default ::reviews]
+  [_model _k birds]
+  (when (seq birds)
+    (let [bird-ids    (not-empty (keep :id birds))
+          all-reviews (when bird-ids
+                        {1 [{:reviewer-id 1
+                             :review      "This is a great bird!"}
+                            {:reviewer-id 2
+                             :review      "I've seen better."}]})]
+      (for [bird birds]
+        (when (some? bird)
+          (assoc bird ::reviews (get all-reviews (:id bird) [])))))))
+
+(m/defmethod hydrate/batched-hydrate [:default ::review-details]
+  [_model _k reviews]
+  (when (seq reviews)
+    (println "reviews:" reviews) ; NOCOMMIT
+    (let [id->user {1 {:name "Cam"}
+                    2 {:name "Sam"}}]
+      (for [review reviews]
+        (assoc review :user (get id->user (:reviewer-id review)))))))
+
 (deftest ^:parallel batched-hydration-test
   (testing "Check that batched hydration doesn't try to hydrate fields that already exist and are not delays"
     (is (= (instance/instance :user {:user-id 1, :user "OK <3"})
@@ -391,7 +413,26 @@
           {:type :pigeon, ::is-bird? true}]
          (hydrate/hydrate [(instance/instance :bird {:type :toucan})
                            (instance/instance :bird {:type :pigeon})]
-                          ::is-bird?))))
+                          ::is-bird?)))
+  (testing "Nested hydration"
+    (is (= [(instance/instance :bird {:type     :toucan
+                                      :id       1
+                                      ::reviews [{:reviewer-id 1, :review "This is a great bird!", :user {:name "Cam"}}
+                                                 {:reviewer-id 2, :review "I've seen better.", :user {:name "Sam"}}]})
+            (instance/instance :bird {:type :pigeon, :id 2, ::reviews []})]
+           (hydrate/hydrate [(instance/instance :bird {:type :toucan, :id 1})
+                             (instance/instance :bird {:type :pigeon, :id 2})]
+                            [::reviews ::review-details])))
+    (testing "with nils"
+      (is (= nil
+             (hydrate/hydrate nil [::reviews ::review-details])))
+      (is (= [nil]
+             (hydrate/hydrate [nil] [::reviews ::review-details])))
+      (is (= [nil
+              (instance/instance :bird {:type :pigeon, :id 2, ::reviews []})]
+             (hydrate/hydrate [nil
+                               (instance/instance :bird {:type :pigeon, :id 2})]
+                              [::reviews ::review-details]))))))
 
 (derive ::people.composite-pk ::people)
 

--- a/test/toucan2/tools/hydrate_test.clj
+++ b/test/toucan2/tools/hydrate_test.clj
@@ -397,7 +397,6 @@
 (m/defmethod hydrate/batched-hydrate [:default ::review-details]
   [_model _k reviews]
   (when (seq reviews)
-    (println "reviews:" reviews) ; NOCOMMIT
     (let [id->user {1 {:name "Cam"}
                     2 {:name "Sam"}}]
       (for [review reviews]


### PR DESCRIPTION
Rather than just the first key. Fixes issues doing batched hydration with sequences like `[nil []]`