### PR TITLE
recur with concat gives stack overflow bugs

### DIFF
--- a/src/toucan2/tools/hydrate.clj
+++ b/src/toucan2/tools/hydrate.clj
@@ -456,7 +456,7 @@
     (if (empty? hydrated-instances)
       (concat acc (map :instance annotated-instances))
       (let [[not-hydrated [_needed-hydration & more]] (split-with (complement :needs-hydration?) annotated-instances)]
-        (recur (concat acc (map :instance not-hydrated) [(first hydrated-instances)])
+        (recur (vec (concat acc (map :instance not-hydrated) [(first hydrated-instances)]))
                more
                (rest hydrated-instances))))))
 


### PR DESCRIPTION
in metabase

```
io.github.camsaul/toucan2                 {#_:mvn/version #_"1.0.516"
                                             :local/root "/Users/dan/projects/work/toucan2"}
```

create a new pg database and sync it empty.

```clojure
  (time
   (let [conn (sql-jdbc.conn/db->pooled-connection-spec 3)]
     (dotimes [n 359]
       (jdbc/execute! conn [(format "create table if not exists foo_%d (id int, col_1 text, col_2 text, col_3 text, col_4 text, col_5 text, col_6 text, col_7 text, col_8 text, col_9 text, col_10 text, col_11 text, col_12 text, col_13 text, col_14 text)" n)]))))

  (sync/sync-database! (db/select-one 'Database :id 3) {:scan :schema})

  (binding [api/*current-user-permissions-set* (delay #{"/"})]
    (count (#'metabase.api.database/db-metadata 3 true true)))
```

before patch:
```clojure
horror=> (binding [api/*current-user-permissions-set* (delay #{"/"})]
           (count (#'metabase.api.database/db-metadata 3 true true)))
Execution error (StackOverflowError) at (REPL:1).
null
```

after patch:

```clojure
horror=> (binding [api/*current-user-permissions-set* (delay #{"/"})]
           (count (#'metabase.api.database/db-metadata 2 true true)))
25
```