### PR TITLE
Avoid copying plain map when converting to instance

### DIFF
--- a/src/toucan2/instance.clj
+++ b/src/toucan2/instance.clj
@@ -16,7 +16,8 @@
    [potemkin :as p]
    [pretty.core :as pretty]
    [toucan2.protocols :as protocols]
-   [toucan2.realize :as realize]))
+   [toucan2.realize :as realize]
+   [toucan2.util :as u]))
 
 (set! *warn-on-reflection* true)
 
@@ -232,11 +233,6 @@
   (pretty [_this]
     (list `->TransientInstance model m mta)))
 
-(defn custom-map?
-  "Is this a map created using p/def-map-type? This includes Instances."
-  [m]
-  (instance-of? potemkin.collections.PotemkinMap m))
-
 (defn instance
   "Create a new Toucan 2 instance. See the namespace docstring for [[toucan2.instance]] for more information about *what*
   a Toucan 2 instance is.
@@ -273,7 +269,7 @@
      ;; (protocols/with-model m model)
 
      ;; Strip any customizations, e.g. a different underlying empty map or key transform.
-     (custom-map? m)
+     (u/custom-map? m)
      (let [m* (into {} m)]
        (->Instance model m* m* (meta m)))
 

--- a/src/toucan2/instance.clj
+++ b/src/toucan2/instance.clj
@@ -232,6 +232,11 @@
   (pretty [_this]
     (list `->TransientInstance model m mta)))
 
+(defn custom-map?
+  "Is this a map created using p/def-map-type? This includes Instances."
+  [m]
+  (instance-of? potemkin.collections.PotemkinMap m))
+
 (defn instance
   "Create a new Toucan 2 instance. See the namespace docstring for [[toucan2.instance]] for more information about *what*
   a Toucan 2 instance is.
@@ -261,11 +266,14 @@
           (= (protocols/model m) model))
      m
 
-      (instance? m)
      ;; DISABLED FOR NOW BECAUSE MAYBE THE OTHER MODEL HAS A DIFFERENT UNDERLYING EMPTY MAP OR KEY TRANSFORM
      ;;
      ;; ;; optimization 2: if `m` is an instance of something else use [[protocols/with-model]]
+     ;; (instance? m)
      ;; (protocols/with-model m model)
+
+     ;; Strip any customizations, e.g. a different underlying empty map or key transform.
+     (custom-map? m)
      (let [m* (into {} m)]
        (->Instance model m* m* (meta m)))
 

--- a/src/toucan2/instance.clj
+++ b/src/toucan2/instance.clj
@@ -261,15 +261,16 @@
           (= (protocols/model m) model))
      m
 
+      (instance? m)
      ;; DISABLED FOR NOW BECAUSE MAYBE THE OTHER MODEL HAS A DIFFERENT UNDERLYING EMPTY MAP OR KEY TRANSFORM
      ;;
      ;; ;; optimization 2: if `m` is an instance of something else use [[protocols/with-model]]
-     ;; (instance? m)
      ;; (protocols/with-model m model)
+     (let [m* (into {} m)]
+       (->Instance model m* m* (meta m)))
 
      :else
-     (let [m* (into {} m)]
-       (->Instance model m* m* (meta m)))))
+     (->Instance model m m (meta m))))
 
   (^toucan2.instance.Instance [model k v & more]
    (let [m (into {} (partition-all 2) (list* k v more))]

--- a/src/toucan2/jdbc/row.clj
+++ b/src/toucan2/jdbc/row.clj
@@ -15,7 +15,8 @@
    [toucan2.instance :as instance]
    [toucan2.log :as log]
    [toucan2.protocols :as protocols]
-   [toucan2.realize :as realize])
+   [toucan2.realize :as realize]
+   [toucan2.util :as u])
   (:import
    (java.sql ResultSet)))
 
@@ -279,6 +280,9 @@
   realize/Realize
   (realize [_this]
     @realized-row)
+
+  u/IsCustomMap
+  (custom-map? [_] true)
 
   (toString [this]
     (str/join \space (map str (print-representation-parts this)))))

--- a/src/toucan2/util.clj
+++ b/src/toucan2/util.clj
@@ -5,7 +5,10 @@
    [clojure.walk :as walk]
    [methodical.util.dispatch :as m.dispatch]
    [pretty.core :as pretty]
-   [toucan2.protocols :as protocols]))
+   [toucan2.protocols :as protocols])
+  (:import
+   (clojure.lang IPersistentMap)
+   (potemkin.collections PotemkinMap)))
 
 ;;; TODO -- there is a lot of repeated code in here to make sure we don't accidentally realize and print `IReduceInit`,
 ;;; and at least 3 places we turn an `eduction` into the same pretty form. Maybe we should try to consolidate some of
@@ -110,3 +113,14 @@
     (keyword (csk/->kebab-case (namespace x))
              (csk/->kebab-case (name x)))
     (csk/->kebab-case x)))
+
+(defprotocol IsCustomMap
+  "Is this a map a transient row, or created using p/def-map-type? This includes Instances."
+  (custom-map? [m]))
+
+(extend-protocol IsCustomMap
+  IPersistentMap
+  (custom-map? [_] false)
+
+  PotemkinMap
+  (custom-map? [_] true))


### PR DESCRIPTION
Closes https://github.com/camsaul/toucan2/issues/164

There's some speculation here, perhaps we need to protect against some other custom map classes.

The use of a protocol is for two reasons:

1. Extensibility in the fringe case that toucan2's used in a application that implements custom maps from scratch.
2. Avoiding reflection on the check. Given that toucan2 is low down the stack its worth avoiding worthless extra work.