### PR TITLE
Add native implementation for IKVReduce in toucan2.instance.Instance

### DIFF
--- a/src/toucan2/instance.clj
+++ b/src/toucan2/instance.clj
@@ -13,6 +13,7 @@
   current value and their model is the same."
   (:refer-clojure :exclude [instance?])
   (:require
+   clojure.core.protocols
    [potemkin :as p]
    [pretty.core :as pretty]
    [toucan2.protocols :as protocols]
@@ -136,6 +137,10 @@
   clojure.lang.IEditableCollection
   (asTransient [_this]
     (->TransientInstance model (transient m) mta))
+
+  clojure.lang.IKVReduce
+  (kvreduce [_this f init]
+    (clojure.core.protocols/kv-reduce m f init))
 
   protocols/IModel
   (protocols/model [_this]

--- a/test/toucan2/instance_test.clj
+++ b/test/toucan2/instance_test.clj
@@ -429,3 +429,8 @@
           m2 (assoc m :location nil)]
       (is (= {:location nil}
              (protocols/changes m2))))))
+
+(deftest ^:parallel reduce-kv-test
+  (testing "instance supports IKVReduce iteration natively"
+    (let [instance (instance/instance ::foo (zipmap (range 100) (range)))]
+      (is (= 100 (.kvreduce instance (fn [c _ _] (inc c)) 0))))))


### PR DESCRIPTION
Without this, if kv-reduce is called on an Instance, the code follows the slow unoptimal path of calling 'reduce' on the map and constructing MapEntries.

This happens notably in Metabase in `instance->metadata` (https://github.com/metabase/metabase/blob/a43b09cdfed17151e4cd2dd34feeecb3f0e012f4/src/metabase/lib/metadata/jvm.clj#L47) but I've seen it in other places too.