### PR TITLE
Bump Honey SQL version & Use JVM Kondo

### DIFF
--- a/.clj-kondo/com.github.seancorfield/next.jdbc/config.edn
+++ b/.clj-kondo/com.github.seancorfield/next.jdbc/config.edn
@@ -1,5 +1,8 @@
 {:hooks
  {:analyze-call
   {next.jdbc/with-transaction
-   hooks.com.github.seancorfield.next-jdbc/with-transaction}}
- :lint-as {next.jdbc/on-connection clojure.core/with-open}}
+   hooks.com.github.seancorfield.next-jdbc/with-transaction
+   next.jdbc/with-transaction+options
+   hooks.com.github.seancorfield.next-jdbc/with-transaction+options}}
+ :lint-as {next.jdbc/on-connection clojure.core/with-open
+           next.jdbc/on-connection+options clojure.core/with-open}}

--- a/.clj-kondo/com.github.seancorfield/next.jdbc/hooks/com/github/seancorfield/next_jdbc.clj_kondo
+++ b/.clj-kondo/com.github.seancorfield/next.jdbc/hooks/com/github/seancorfield/next_jdbc.clj_kondo
@@ -1,0 +1,34 @@
+(ns hooks.com.github.seancorfield.next-jdbc
+  (:require [clj-kondo.hooks-api :as api]))
+
+(defn with-transaction
+  "Expands (with-transaction [tx expr opts] body)
+  to (let [tx expr] opts body) per clj-kondo examples."
+  [{:keys [:node]}]
+  (let [[binding-vec & body] (rest (:children node))
+        [sym val opts] (:children binding-vec)]
+    (when-not (and sym val)
+      (throw (ex-info "No sym and val provided" {})))
+    (let [new-node (api/list-node
+                    (list*
+                     (api/token-node 'let)
+                     (api/vector-node [sym val])
+                     opts
+                     body))]
+      {:node new-node})))
+
+(defn with-transaction+options
+  "Expands (with-transaction+options [tx expr opts] body)
+  to (let [tx expr] opts body) per clj-kondo examples."
+  [{:keys [:node]}]
+  (let [[binding-vec & body] (rest (:children node))
+        [sym val opts] (:children binding-vec)]
+    (when-not (and sym val)
+      (throw (ex-info "No sym and val provided" {})))
+    (let [new-node (api/list-node
+                    (list*
+                     (api/token-node 'let)
+                     (api/vector-node [sym val])
+                     opts
+                     body))]
+      {:node new-node})))

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,27 +10,15 @@ jobs:
   kondo:
     runs-on: ubuntu-20.04
     timeout-minutes: 10
-    env:
-      CLJ_KONDO_VERSION: "2023.09.07"
-      DOWNLOAD_URL: https://github.com/clj-kondo/clj-kondo/releases/download
     steps:
     - uses: actions/checkout@v4.1.7
     - name: Setup Java & Clojure
       uses: ./.github/actions/setup
       with:
         cache-key: kondo
-    - name: Install clj-kondo
-      run: |
-        curl -OL ${DOWNLOAD_URL}/v${CLJ_KONDO_VERSION}/clj-kondo-${CLJ_KONDO_VERSION}-linux-static-amd64.zip
-        curl -OL ${DOWNLOAD_URL}/v${CLJ_KONDO_VERSION}/clj-kondo-${CLJ_KONDO_VERSION}-linux-static-amd64.zip.sha256
-        cat clj-kondo-${CLJ_KONDO_VERSION}-linux-static-amd64.zip.sha256 >> SHA256sum.txt
-        echo " clj-kondo-${CLJ_KONDO_VERSION}-linux-static-amd64.zip" >> SHA256sum.txt
-        sha256sum -c SHA256sum.txt
-        unzip -d /usr/local/bin clj-kondo-${CLJ_KONDO_VERSION}-linux-static-amd64.zip
-    - run: clj-kondo --version
     - name: Copy Kondo config from deps
       run: >-
-        clj-kondo
+        clojure -M:kondo
         --copy-configs
         --dependencies
         --lint "$(clojure -A:dev -Spath)"
@@ -38,13 +26,7 @@ jobs:
         --parallel
     - name: Run clj-kondo
       run: >-
-        clj-kondo
-        --parallel
-        --lint
-        src
-        test
-        toucan1/src
-        toucan1/test
+        clojure -M:kondo:kondo/all
 
   tests-postgres:
     runs-on: ubuntu-20.04
@@ -139,7 +121,7 @@ jobs:
     - run: clojure -X:dev:test-h2:cloverage
       name: Run tests with Cloverage
     - name: Upload results to codecov.io
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4.5.0
       with:
         files: ./target/coverage/codecov.json
 

--- a/deps.edn
+++ b/deps.edn
@@ -4,7 +4,7 @@
  :deps
  {better-cond/better-cond             {:mvn/version "2.1.5"}
   camel-snake-kebab/camel-snake-kebab {:mvn/version "0.4.3"}
-  com.github.seancorfield/honeysql    {:mvn/version "2.4.1066"} ; don't upgrade yet because of https://github.com/seancorfield/honeysql/issues/537
+  com.github.seancorfield/honeysql    {:mvn/version "2.6.1147"}
   com.github.seancorfield/next.jdbc   {:mvn/version "1.3.939"}
   environ/environ                     {:mvn/version "1.2.0"}
   methodical/methodical               {:mvn/version "1.0.123"}
@@ -59,6 +59,28 @@
    :exec-args  {:paths            ["deps.edn" "src" "test" "toucan1/src" "toucan1/test" ".github" "docs"]
                 :include-patterns ["\\.clj[cs]?$" "\\.edn$" "\\.yaml$" "\\.sql$" "\\.md$"]}}
 
+  ;; Run Kondo
+  ;;
+  ;;    clojure -M:kondo --lint ...
+  ;;
+  ;; Copy configs
+  ;;
+  ;;    clojure -M:kondo --copy-configs --dependencies --lint "$(clojure -A:dev -Spath)" --skip-lint --parallel
+  :kondo
+  {:replace-deps {clj-kondo/clj-kondo {:mvn/version "2023.09.07" #_"2024.08.01"}}
+   :main-opts    ["-m" "clj-kondo.main"]}
+
+  ;; lint everything with Kondo
+  ;;
+  ;; clojure -M:kondo:kondo/all
+  :kondo/all
+  {:main-opts ["-m" "clj-kondo.main"
+               "--lint"
+               "src"
+               "test"
+               "toucan1/src"
+               "toucan1/test"]}
+
   ;; Run tests against the value of `TEST_DBS`, by default `postgres,h2,mariadb`.
   ;;
   ;; clojure -X:dev:test
@@ -102,7 +124,10 @@
 
   ;; clj -X:dev:cloverage
   :cloverage
-  {:extra-deps {cloverage/cloverage {:mvn/version "1.2.4"}}
+  {:extra-deps
+   {cloverage/cloverage              {:mvn/version "1.2.4"}
+    com.github.seancorfield/honeysql {:sha "bf34a23e6874c0c7c03b81e69b9eaddf06c2caa9"}} ; override pinned version with fix for https://github.com/seancorfield/honeysql/issues/537 which is not released yet
+
    :exec-fn    toucan2.cloverage-runner/run-project
    :exec-args  {:codecov? true
 


### PR DESCRIPTION
Sean Corfield pushed a commit that fixes https://github.com/seancorfield/honeysql/issues/537 so we can use that for running Cloverage now.

Also switch to running Kondo with `clojure`/`deps.edn` so we don't need to download and install it in CI and can easily pin a specific version locally