### PR TITLE
[hydrate] Use cached Methodical function to check for mm implementation

### DIFF
--- a/src/toucan2/tools/hydrate.clj
+++ b/src/toucan2/tools/hydrate.clj
@@ -418,7 +418,7 @@
 
 (m/defmethod can-hydrate-with-strategy? [#_model :default #_strategy ::multimethod-batched #_k :default]
   [model _strategy k]
-  (boolean (m/effective-primary-method batched-hydrate (m/dispatch-value batched-hydrate model k))))
+  (some? (m/effective-method batched-hydrate (m/dispatch-value batched-hydrate model k))))
 
 ;;; The basic strategy behind batched hydration is thus:
 ;;;
@@ -491,7 +491,7 @@
 
 (m/defmethod can-hydrate-with-strategy? [#_model :default #_strategy ::multimethod-simple #_k :default]
   [model _strategy k]
-  (boolean (m/effective-primary-method simple-hydrate (m/dispatch-value simple-hydrate model k))))
+  (some? (m/effective-method simple-hydrate (m/dispatch-value simple-hydrate model k))))
 
 (m/defmethod hydrate-with-strategy ::multimethod-simple
   [model _strategy k instances]


### PR DESCRIPTION
`m/effective-primary-method`, which was used in `can-hydrate-with-strategy?` to check if a particular hydration strategy is available for a model, constructs a primary method every time it is invoked. Instead, `m/effective-method` will try to lookup a cached method for the given dispatch value if the mm is a CachedMultiFnImpl (it is by default).

Note that caching only works for hits. If the method isn't implemented for a particular dispatch value, Methodical will go through the expensive process of trying to construct a method.