### PR TITLE
[log] Add primitive hints to logging level functions

### DIFF
--- a/src/toucan2/log.clj
+++ b/src/toucan2/log.clj
@@ -148,7 +148,7 @@
         texts   (map ->Text* (str/split format-string #"%s"))]
     `(->Doc ~(vec (interleave-all texts args)))))
 
-(defn- level->int [a-level default]
+(defn- level->int ^long [a-level ^long default]
   (case a-level
     :disabled 5
     :error    4
@@ -163,7 +163,7 @@
 ;;; convenient.
 (defn ^:no-doc -current-level-int
   "Current log level, as an integer."
-  []
+  ^long []
   (level->int (or *level* @level) Integer/MAX_VALUE))
 
 (defmacro ^:no-doc -enable-level?


### PR DESCRIPTION
Currently, Toucan's logging macros always produce allocation overhead by converting between primitive ints and Integer objects. This change ensures that primitive arities are chosen, and hence, there are no allocations if the logging level mismatches the logging statement.