### PR TITLE
[jdbc.read] Don't track realized keys in TransientRow

### DIFF
--- a/test/toucan2/jdbc/row_test.clj
+++ b/test/toucan2/jdbc/row_test.clj
@@ -33,7 +33,7 @@
           (select/reducible-select ::test/venues 1)))))
 
 (defn- realized-keys [^TransientRow row]
-  @(.realized_keys row))
+  (set (keys (second (#'jdbc.row/print-representation-parts row)))))
 
 (defn- already-realized? [^TransientRow row]
   (realized? (.realized_row row)))


### PR DESCRIPTION
Tracking the hashset of realized keys for each row in the resultset has noticeable overhead. Since this is only needed to print the transient row during debugging (as far as I can tell), it makes sense to shave the overhead here. All column names can be computed upfront and then used to print the values available in transient row. Please tell me if I'm wrong or missing something.