### PR TITLE
[jdbc.read] Properly pre-compute column fetching thunk

### DIFF
--- a/src/toucan2/jdbc/read.clj
+++ b/src/toucan2/jdbc/read.clj
@@ -130,11 +130,10 @@
 
 (defn- make-column-thunk [conn model ^ResultSet rset i]
   (log/tracef "Building thunk to read column %s" i)
-  (fn column-thunk []
-    (let [rsmeta (.getMetaData rset)
-          thunk  (read-column-thunk conn model rset rsmeta i)
-          v      (thunk)]
-      (next.jdbc.rs/read-column-by-index v rsmeta i))))
+  (let [rsmeta (.getMetaData rset)
+        thunk (read-column-thunk conn model rset rsmeta i)]
+    (fn column-thunk []
+      (next.jdbc.rs/read-column-by-index (thunk) rsmeta i))))
 
 (defn ^:no-doc make-i->thunk
   "Given a connection `conn`, a `model` and a result set `rset`, return a function which given a column number `i` returns


### PR DESCRIPTION
Thanks to your comment on #179 I finally understood what is the deal with column thinks and such. This PR moves computing the thunk to where it should be – outside of the returned lambda, so that the machinery is not re-run for every row. The benchmark from #185 gives this:

```
master (results are reused):
Time per call: 18.89 ms   Alloc per call: 17,484,278b
Time per call: 18.90 ms   Alloc per call: 17,483,998b
Time per call: 18.87 ms   Alloc per call: 17,483,817b

After PR:
Time per call: 9.83 ms   Alloc per call: 11,968,423b   Iterations: 209
Time per call: 9.99 ms   Alloc per call: 11,968,262b   Iterations: 201
Time per call: 9.76 ms   Alloc per call: 11,968,255b   Iterations: 209
```