### PR TITLE
[jdbc.row] Reduce allocations in fetch-all-columns!

### DIFF
--- a/src/toucan2/jdbc/row.clj
+++ b/src/toucan2/jdbc/row.clj
@@ -331,10 +331,12 @@
 
 (defn- fetch-all-columns! [builder i->thunk transient-row]
   (log/tracef "Fetching all columns")
-  (reduce
-   (partial fetch-column! builder i->thunk)
-   transient-row
-   (range 1 (inc (next.jdbc.rs/column-count builder)))))
+  (let [n (next.jdbc.rs/column-count builder)]
+    (loop [i 1
+           transient-row transient-row]
+      (if (<= i n)
+        (recur (inc i) (fetch-column! builder i->thunk transient-row i))
+        transient-row))))
 
 (defn- make-realized-row-delay [builder i->thunk ^clojure.lang.Volatile volatile-transient-row]
   (delay


### PR DESCRIPTION
This doesn't look much like an improvement but it actually removes two sources of allocations per each row – the LongRange and the lambda created by `partial`. This accounts for ~10% of allocations in my "select 10k rows" benchmark, and it costs nothing to optimize it (except maybe a bit of readability).