### PR TITLE
[jdbc.row] Replace memoize in lazy thunk construction with delays

### DIFF
--- a/src/toucan2/jdbc/read.clj
+++ b/src/toucan2/jdbc/read.clj
@@ -138,10 +138,12 @@
 (defn ^:no-doc make-i->thunk
   "Given a connection `conn`, a `model` and a result set `rset`, return a function which given a column number `i` returns
   a thunk that retrieves the column value of the current row from the result set."
-  [conn model rset]
-  (comp (memoize (fn [i]
-                   (make-column-thunk conn model rset i)))
-        int))
+  [conn model ^ResultSet rset]
+  (let [n (.getColumnCount (.getMetaData rset))
+        thunks (vec (for [i (range n)]
+                      (delay (make-column-thunk conn model rset (inc i)))))]
+    (fn [i]
+      @(nth thunks (dec i)))))
 
 (defn ^:no-doc read-column-by-index-fn
   "Given a `i->thunk` function, return a function that can be used with [[next.jdbc.result-set/builder-adapter]]. The

--- a/src/toucan2/jdbc/read.clj
+++ b/src/toucan2/jdbc/read.clj
@@ -140,8 +140,9 @@
   a thunk that retrieves the column value of the current row from the result set."
   [conn model ^ResultSet rset]
   (let [n (.getColumnCount (.getMetaData rset))
-        thunks (vec (for [i (range n)]
-                      (delay (make-column-thunk conn model rset (inc i)))))]
+        thunks (mapv (fn [i]
+                       (delay (make-column-thunk conn model rset (inc i))))
+                     (range n))]
     (fn [i]
       @(nth thunks (dec i)))))
 


### PR DESCRIPTION
I'll need your feedback on this PR as it's not as clear-cut as the other ones. `memoize` is quite inefficient on a per-call basis (either a hit or a miss). The cheapest (amortized) way to look up per-column thunks is to compute them early and put into a vector. This is the best thing to do for regular selects where the whole row is realized anyway. However, it may be doing unnecessary work for other types of select where only one column is extracted, or PKs, or whatever.

Still, the overhead would only happen once per ResultSet, not per each value cell like now. I'll defer to your judgement.

An alternative would be to roll out a custom memoize-like structure for this (e.g. vector in an atom).