### PR TITLE
Comment out log traces

### DIFF
--- a/src/toucan2/jdbc/read.clj
+++ b/src/toucan2/jdbc/read.clj
@@ -69,7 +69,7 @@
   [_conn _model ^ResultSet rset _rsmeta ^Long i]
   (log/debugf "Fetching values in column %s with %s" i (list '.getObject 'rs i))
   (fn default-read-column-thunk []
-    (log/tracef "col %s => %s" i (list '.getObject 'rset i))
+    ;; (log/tracef "col %s => %s" i (list '.getObject 'rset i))
     (.getObject rset i)))
 
 (m/defmethod read-column-thunk :after :default
@@ -98,7 +98,7 @@
     ;; from Criterium: a no-op call takes about 20ns locally. So 10m rows => 200ms from this no-op call. That's a little
     ;; expensive, but probably not as bad as the overhead we get from other nonsense here in Toucan 2. We'll have to do
     ;; some general performance tuning in the future.
-    (log/tracef "col %s => %s" i (list '.getObject 'rset i klass))
+    ;; (log/tracef "col %s => %s" i (list '.getObject 'rset i klass))
     (.getObject rset i klass)))
 
 ;;;; Default column read methods

--- a/src/toucan2/jdbc/result_set.clj
+++ b/src/toucan2/jdbc/result_set.clj
@@ -36,7 +36,7 @@
 (defrecord ^:no-doc InstanceBuilder [model ^ResultSet rset ^ResultSetMetaData rsmeta cols]
   next.jdbc.rs/RowBuilder
   (->row [_this]
-    (log/tracef "Fetching row %s" (.getRow rset))
+    ;; (log/tracef "Fetching row %s" (.getRow rset))
     (transient (instance/instance model)))
 
   (column-count [_this]
@@ -54,7 +54,7 @@
     (assoc! row col v))
 
   (row! [_this row]
-    (log/tracef "Converting transient row to persistent row")
+    ;; (log/tracef "Converting transient row to persistent row")
     (persistent! row))
 
   next.jdbc.rs/ResultSetBuilder
@@ -151,7 +151,7 @@
           (log/tracef "Result set has no more rows.")
           acc)
 
-        :let [_        (log/tracef "Fetch row %s" (.getRow rset))
+        :let [;; _     (log/tracef "Fetch row %s" (.getRow rset))
               row      (jdbc.row/row model rset builder i->thunk col-name->index)
               acc'     (rf acc row)]
 

--- a/src/toucan2/jdbc/row.clj
+++ b/src/toucan2/jdbc/row.clj
@@ -330,7 +330,7 @@
       transient-row)))
 
 (defn- fetch-all-columns! [builder i->thunk transient-row]
-  (log/tracef "Fetching all columns")
+  ;; (log/tracef "Fetching all columns")
   (let [n (next.jdbc.rs/column-count builder)]
     (loop [i 1
            transient-row transient-row]
@@ -340,7 +340,7 @@
 
 (defn- make-realized-row-delay [builder i->thunk ^clojure.lang.Volatile volatile-transient-row]
   (delay
-    (log/tracef "Fully realizing row. *fetch-all-columns* = %s" *fetch-all-columns*)
+    ;; (log/tracef "Fully realizing row. *fetch-all-columns* = %s" *fetch-all-columns*)
     (let [row (cond->> @volatile-transient-row
                 *fetch-all-columns* (fetch-all-columns! builder i->thunk))]
       (next.jdbc.rs/row! builder row))))


### PR DESCRIPTION
As discussed in #184, this solution is simpler and more efficient than that PR if the approach is viable.

10k rows benchmark against current master:

```
master:
Time per call: 7.49 ms   Alloc per call: 11,088,805b
Time per call: 7.45 ms   Alloc per call: 11,088,041b
Time per call: 7.63 ms   Alloc per call: 11,087,626b

no per-cell traces (10% improvement):
Time per call: 6.74 ms   Alloc per call: 11,086,952b
Time per call: 6.73 ms   Alloc per call: 11,086,286b
Time per call: 6.73 ms   Alloc per call: 11,085,933b

No per-row traces (another 14% improvement):
Time per call: 5.63 ms   Alloc per call: 11,085,107b
Time per call: 5.83 ms   Alloc per call: 11,084,783b
Time per call: 5.63 ms   Alloc per call: 11,084,576b
```

At first I thought to remove only the per-cell traces but the per-row ones are contributing quite a lot still.