### PR TITLE
Fix a footgun in `before-update`

### DIFF
--- a/src/toucan2/tools/before_update.clj
+++ b/src/toucan2/tools/before_update.clj
@@ -49,20 +49,22 @@
      ;; After going back and forth on this I've concluded that it's probably best to just realize the entire row here.
      ;; There are a lot of situations where we don't need to do this, but it means we have to step on eggshells
      ;; everywhere else in order to make things work nicely. Maybe we can revisit this in the future.
-     (let [row         (realize/realize row)
-           row         (merge row changes)
-           row         (before-update model row)
+     (let [realized-row (realize/realize row)
+           row          (merge row changes)
+           row          (before-update model row)
            ;; if the `before-update` method returned a plain map then consider that to be the changes.
            ;; `protocols/changes` will return `nil` for non-instances. TODO -- does that behavior make sense? Clearly,
            ;; it's easy to use wrong -- it took me hours to figure out why something was working and that I needed to
            ;; make this change :sad:
-           row-changes (if (instance/instance? row)
-                         (protocols/changes row)
-                         row)]
+           row-changes  (if (instance/instance? row)
+                          (protocols/changes row)
+                          row)
+           pks          (model/primary-key-values-map model realized-row)]
        (log/tracef "The following values have changed: %s" changes)
+       (assert (seq pks) "No primary key(s) were found on the realized row")
        (cond-> changes->pks
-         (seq row-changes) (update row-changes (fn [pks]
-                                                 (conj (set pks) (model/primary-key-values-map model row)))))))))
+         (seq row-changes) (update row-changes (fn [pks*]
+                                                 (conj (set pks*) pks))))))))
 
 (defn- fetch-changes->pk-maps [model {:keys [changes], :as parsed-args} resolved-query]
   (not-empty

--- a/src/toucan2/tools/before_update.clj
+++ b/src/toucan2/tools/before_update.clj
@@ -50,7 +50,7 @@
      ;; There are a lot of situations where we don't need to do this, but it means we have to step on eggshells
      ;; everywhere else in order to make things work nicely. Maybe we can revisit this in the future.
      (let [realized-row (realize/realize row)
-           row          (merge row changes)
+           row          (merge realized-row changes)
            row          (before-update model row)
            ;; if the `before-update` method returned a plain map then consider that to be the changes.
            ;; `protocols/changes` will return `nil` for non-instances. TODO -- does that behavior make sense? Clearly,

--- a/test/toucan2/tools/after_update_test.clj
+++ b/test/toucan2/tools/after_update_test.clj
@@ -137,7 +137,7 @@
                  ::venues.exception.db-land      (case (test/current-db-type)
                                                    :postgres #"ERROR: column \"venue_name\" of relation \"venues\" does not exist"
                                                    :h2       #"Column \"VENUE_NAME\" not found"
-                                                   :mariadb  #"Unknown column 'venue_name' in 'field list'"))
+                                                   :mariadb  #"Unknown column 'venue_name' in 'SET'"))
                (update/update! model 2 {:category "store", :name "My Store"})))
           (testing "\nShould be done inside a transaction"
             (is (= [(instance/instance model


### PR DESCRIPTION
In a very precise condition, we would emit an `UPDATE` clause without
any `WHERE` condition at all:

- the `before-update` method's result does not have a primary key

- the `where` clause in an `update!` call matches multiple rows

- some part of the update map will change all matched rows

- another part of the update map will change only a subset of matched
rows

If all these conditions are met, the bug is triggered and we emit an
UPDATE without any `WHERE` clause at all.

This fixes the issue by making sure to get the primary keys from the
realized row rather than from the result of
`(before-update (merge realized-row changes))`. I also added tests as
well as an assertion that a primary key is actually present, since its
absence is so dangerous.
