### PR TITLE
[model] Use hand-rolled select-keys implementation

### DIFF
--- a/src/toucan2/model.clj
+++ b/src/toucan2/model.clj
@@ -143,7 +143,12 @@
   ([instance]
    (primary-key-values-map (protocols/model instance) instance))
   ([model m]
-   (select-keys m (primary-keys model))))
+   ;; clojure.core/select-keys is quite inefficient on Toucan2 Instances; using a custom implementation.
+   (let [ks (set (primary-keys model))]
+     (reduce-kv (fn [acc k v]
+                  (cond-> acc
+                    (contains? ks k) (assoc k v)))
+                {} m))))
 
 ;;; TODO -- consider renaming this to something better. What?
 (defn select-pks-fn


### PR DESCRIPTION
`select-keys` is one of the criminally inefficient functions for no good reason (it uses `reduce1` which is terrible by its own). Combined with the fact that `toucan2.instance.Instance` doesn't provide a straightforward `entryAt` implementation, select-keys performs especially poorly on Toucan instances. This custom select-keys implementation is more efficient given the circumstances.

If necessary, this custom implementation can be extracted somewhere into util namespace. However; there are only a few `select-keys` usages across Toucan, and only this one is performance-sensitive.