### PR TITLE
Rewrite empty [:in col []] clauses to false before compiling

### DIFF
--- a/src/toucan2/honeysql2.clj
+++ b/src/toucan2/honeysql2.clj
@@ -2,6 +2,7 @@
   (:require
    [better-cond.core :as b]
    [clojure.string :as str]
+   [clojure.walk :as walk]
    [honey.sql :as hsql]
    [honey.sql.helpers :as hsql.helpers]
    [methodical.core :as m]
@@ -274,12 +275,30 @@
 
 ;;;; Query compilation
 
+(defn- empty-in-clause?
+  "Matches HoneySQL [:in column coll] forms where coll is empty.
+   These produce invalid SQL syntax like `X IN ()` which we need to rewrite."
+  [form]
+  (when (and (vector? form) (= 3 (count form)))
+    (let [[op _ coll] form]
+      (and (= :in op)
+           (seqable? coll)
+           (empty? coll)
+           (not (map? coll))))))
+
+(defn- rewrite-empty-in-clauses [form]
+  (walk/postwalk #(if (empty-in-clause? %) false %) form))
+
 (m/defmethod pipeline/compile [#_query-type :default
                                #_model      :default
                                #_query      clojure.lang.IPersistentMap]
   "Compile a Honey SQL 2 map to [sql & args]."
   [query-type model honeysql]
-  (let [options-map (options)
+  ;; HoneySQL generates invalid `X IN ()` for empty collections. It offers `:checking :basic`
+  ;; to throw an exception, but as a thin DSL it won't auto-fix. Toucan2 is more opinionated,
+  ;; so we rewrite to `false` here to make things "just work".
+  (let [honeysql    (rewrite-empty-in-clauses honeysql)
+        options-map (options)
         _           (log/debugf "Compiling Honey SQL 2 with options %s" options-map)
         sql-args    (u/try-with-error-context ["compile Honey SQL to SQL" {::honeysql honeysql, ::options-map options-map}]
                       (hsql/format honeysql options-map))]

--- a/test/toucan2/honeysql2_test.clj
+++ b/test/toucan2/honeysql2_test.clj
@@ -41,3 +41,27 @@
     [:b :a.c [:d :e]] [:x :y] [:y/b :a.c [:d :e]] ; ignore non-keywords
     [:b :a.c nil]     [:x :y] [:y/b :a.c nil]     ; ignore non-keywords
     [:a/b :a.c :d]    [:x]    [:a/b :a.c :x/d]))  ; ignore namespaced keywords
+
+(deftest ^:parallel rewrite-empty-in-clauses-test
+  (are [keep? where] (= {:where (if keep? where false)}
+                         (#'t2.honeysql/rewrite-empty-in-clauses {:where where}))
+    false [:in :id []]
+    false [:in :id nil]
+    false [:in :id '()]
+    false [:in :id #{}]
+    false [:in :id (lazy-seq [])]
+    true  [:in :id [1]]
+    true  [:in :id #{1}]
+    true  [:in :id (lazy-seq [1])]
+    true  [:in :id {}]
+    true  [:in :id {:select [:id] :from [:other]}]
+    true  [:in :id 1]
+    true  [:in :id "invalid"]
+    true  [:> :id 5]
+    true  [:= :id 1]
+    true  {:select [:*]}
+    true  "not a vector"
+    true  nil)
+  (testing "rewrites nested empty IN clauses"
+    (is (= {:where [:and [:= :a 1] false]}
+           (#'t2.honeysql/rewrite-empty-in-clauses {:where [:and [:= :a 1] [:in :id []]]})))))


### PR DESCRIPTION
## Problem

Using `[:in column []]` with an empty collection generates invalid SQL syntax `X IN ()`. 

If null is the billion dollar mistake, empty IN clauses are the quintillion sorrows tragedy - collections are often dynamically generated and happen to be empty at runtime.

## Why not fix this in HoneySQL?

HoneySQL intentionally doesn't fix stuff like this. As a thin SQL DSL, it offers `:checking :basic` which throws an exception for empty IN clauses, but considers automatic rewriting too opinionated/magical for its scope. 

- [seancorfield/honeysql#315](https://github.com/seancorfield/honeysql/issues/315)
- [seancorfield/honeysql#321](https://github.com/seancorfield/honeysql/issues/321)

## Why fix it here?

Toucan2 is explicitly more opinionated, and having it just do what it knows we mean seems fine.

(As an aside, HoneySQL's `:checking :basic` wouldn't help us anyway - we want correct behavior, not exceptions. And it's too strict in other ways, disallowing unqualified DELETEs and UPDATEs that we have legitimate use cases for.)

## Implementation

Walks the HoneySQL map in `pipeline/compile` and rewrites empty IN clauses to `false`. 
Subqueries and invalid forms pass through unchanged.