### PR TITLE
Add unshared connections: used when passed explicitly, never bound ambiently

### DIFF
--- a/src/toucan2/connection.clj
+++ b/src/toucan2/connection.clj
@@ -67,6 +67,42 @@
   an explicit will connectable will use it rather than the `:default` connection."
   nil)
 
+(defonce ^:private unshared-connections
+  ;; identity-weak set: an entry disappears when its connection is garbage collected, so a mark can never
+  ;; outlive the connection object it applies to
+  (java.util.Collections/newSetFromMap
+   (java.util.Collections/synchronizedMap (java.util.WeakHashMap.))))
+
+(defn unshared-connection!
+  "Mark an open connection as *unshared*: Toucan will still execute queries and transactions on it when you pass
+  it explicitly, but will never bind it to [[*current-connectable*]] -- while it is in use,
+  [[*current-connectable*]] is bound to `nil`, so code running inside a query or transaction on this connection
+  that resolves its connection *ambiently* (e.g. `(t2/select ...)` with no explicit connectable) gets the
+  `:default` connectable instead of this connection.
+
+  Use this for a connection whose state must not be disturbed by unrelated work that happens to run while it is
+  in use: a streaming result set (a PostgreSQL portal/cursor dies if anything else commits on its connection
+  mid-iteration), or a connection holding row locks that must survive other queries. Note this cuts both ways:
+  a transaction opened on an unshared connection does *not* propagate to ambient calls in its body -- they run
+  (and commit) on their own connections -- so don't mark a connection whose transaction ambient work is
+  expected to join.
+
+  The mark lasts for the lifetime of the connection object and cannot be removed. Returns the connection:
+
+  ```clj
+  (with-open [conn (.getConnection my-datasource)]
+    (t2/unshared-connection! conn)
+    ...)
+  ```"
+  [conn]
+  (.add ^java.util.Set unshared-connections conn)
+  conn)
+
+(defn unshared-connection?
+  "Whether `conn` has been marked as [[unshared-connection!]]."
+  [conn]
+  (.contains ^java.util.Set unshared-connections conn))
+
 (m/defmulti do-with-connection
   "Take a *connectable*, get a connection of some sort from it, and execute `(f connection)` with an open connection. A
   normal implementation might look something like:
@@ -96,11 +132,15 @@
 
 (defn- bind-current-connectable-fn
   "Wrap functions as passed to [[do-with-connection]] or [[do-with-transaction]] in a way that
-  binds [[*current-connectable*]]."
+  binds [[*current-connectable*]]. An [[unshared-connection!]] is never bound -- `nil` is bound in its place,
+  shadowing any outer binding (including the pipeline's transport of an explicit `:connectable`, see
+  [[toucan2.pipeline/transduce-parsed]]), so ambient resolution inside `f` falls through to the `:default`
+  connectable rather than ever seeing the connection."
   [f]
   {:pre [(fn? f)]}
   (^:once fn* [conn]
-   (binding [*current-connectable* conn]
+   (binding [*current-connectable* (when-not (unshared-connection? conn)
+                                     conn)]
      (f conn))))
 
 (m/defmethod do-with-connection :around ::default

--- a/src/toucan2/core.clj
+++ b/src/toucan2/core.clj
@@ -63,6 +63,8 @@
 (p/import-vars
  [toucan2.connection
   do-with-connection
+  unshared-connection!
+  unshared-connection?
   with-connection
   with-transaction]
 

--- a/test/toucan2/connection_test.clj
+++ b/test/toucan2/connection_test.clj
@@ -2,6 +2,7 @@
   "Tests for the default JDBC implementation live in [[toucan2.jdbc.connection-test]]."
   (:require
    [clojure.test :refer :all]
+   [methodical.core :as m]
    [toucan2.connection :as conn]))
 
 (deftest ^:parallel connection-string-protocol-test
@@ -13,3 +14,26 @@
     (testing (pr-str `(conn/connection-string-protocol ~s))
       (is (= expected
              (conn/connection-string-protocol s))))))
+
+(m/defmethod conn/do-with-connection ::shared-test-connectable
+  [_connectable f]
+  (f (Object.)))
+
+(m/defmethod conn/do-with-connection ::unshared-test-connectable
+  [_connectable f]
+  (f (conn/unshared-connection! (Object.))))
+
+(deftest ^:parallel unshared-connection-not-bound-as-current-connectable-test
+  (testing "a normal connection is bound as *current-connectable* while in use"
+    (conn/do-with-connection
+     ::shared-test-connectable
+     (fn [conn]
+       (is (identical? conn conn/*current-connectable*)))))
+  (testing "an unshared connection is handed to f but never bound; ambient resolution is suppressed entirely"
+    (binding [conn/*current-connectable* ::previous]
+      (conn/do-with-connection
+       ::unshared-test-connectable
+       (fn [conn]
+         (is (conn/unshared-connection? conn))
+         (testing "*current-connectable* is nil, shadowing any outer binding, so ambient use falls to :default"
+           (is (nil? conn/*current-connectable*))))))))


### PR DESCRIPTION
## Problem

An open connection can hold fragile long-lived state: a streaming result set (a PostgreSQL portal/cursor dies if anything else commits on its connection mid-iteration), or `FOR UPDATE` row locks that must survive unrelated work. Ambient connection reuse via `*current-connectable*` silently hands such a connection to any code that runs while it is in use — e.g. the reducing fn of a long-running reducible query — and a nested `with-transaction` commit there destroys the owner's state (`ERROR: portal "C_…" does not exist`).

This is the failure mode behind several Metabase incidents: metabase/metabase#78238 (10–25 min first-boot hang), and the revert (metabase/metabase#77048) of appdb streaming (metabase/metabase#76645), which concluded at the time that the problem "cannot be fixed" — because there was no way to hold a connection toucan wouldn't re-advertise.

## Semantics

`(unshared-connection! conn)` marks a connection as *unshared*:

- Toucan still executes queries and transactions on it when **passed it explicitly** — `(t2/reducible-query conn …)`, `(t2/with-transaction [t conn] …)` all work.
- It is **never bound to `*current-connectable*`**: while it is in use, `*current-connectable*` is bound to `nil`, so code inside that resolves its connection ambiently gets the `:default` connectable instead.

Explicit possession is the owner's capability; ambient resolution is the borrower's path, and borrowers get their own connections. Note this cuts both ways (documented in the docstring): a transaction on an unshared connection does not propagate to ambient calls in its body.

## Implementation notes

- The mark lives in an identity-weak set, so it cannot outlive the connection object and imposes no lifecycle bookkeeping on callers.
- The only behavior change is one conditional in `bind-current-connectable-fn`, the single choke point both `do-with-connection :around` and `do-with-transaction :around` route through. Unmarked connections behave exactly as before; the full h2 test suite passes unchanged.
- Binding `nil` (rather than simply not binding) is load-bearing: `transduce-parsed` transports an explicit `:connectable` to the execution layer *through* `*current-connectable*` itself, and that binding stays in scope for the whole reduction. The `nil` shadow suppresses it for exactly the dynamic extent of the query — without it, the connection leaks to the reducing fn through the transport binding. (Related to the existing TODO in `transduce-parsed` about these semantics.)

Consumer side in Metabase (branch pending on this PR): a four-line `with-unshared-connection` macro — checkout, mark, hand to body, close — with an end-to-end test where a `:fetch-size` streaming `reducible-query` on postgres survives a nested ambient `with-transaction` commit mid-reduction, while the unmarked control reproduces the portal death.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7FfdpzW5pr7CX9aNwa98f