### PR TITLE
Fix generated-key handling for mariadb-java-client 3.x on MySQL/MariaDB

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -24,11 +24,11 @@
     org.clojure/java.classpath           {:mvn/version "1.1.0"}
     org.clojure/math.combinatorics       {:mvn/version "0.3.0"}
     org.clojure/tools.namespace          {:mvn/version "1.5.0"}
-    ;; Don't upgrade to 3.x yet. It only returns the first generated key when inserting multiple rows. So keep using v2
-    ;; until we decide how to work around it or they fix it. See
-    ;;
-    ;; https://mariadb.com/kb/en/about-mariadb-connector-j/#generated-keys-limitation
-    org.mariadb.jdbc/mariadb-java-client {:mvn/version "2.7.8"}
+    ;; 3.x only returns the first generated key when inserting multiple rows in one statement (see
+    ;; https://mariadb.com/kb/en/about-mariadb-connector-j/#generated-keys-limitation) -- worked around in
+    ;; [[toucan2.jdbc.mysql-mariadb]] by executing multi-row inserts returning PKs as a JDBC batch. Note that 3.x
+    ;; only claims `jdbc:mysql:` URLs whose URL string contains `permitMysqlScheme`.
+    org.mariadb.jdbc/mariadb-java-client {:mvn/version "3.5.9"}
     org.postgresql/postgresql            {:mvn/version "42.7.4"}
     pjstadig/humane-test-output          {:mvn/version "0.11.0"}}
 

--- a/src/toucan2/jdbc/mysql_mariadb.clj
+++ b/src/toucan2/jdbc/mysql_mariadb.clj
@@ -2,15 +2,18 @@
   "MySQL and MariaDB integration (mostly workarounds for broken stuff)."
   (:require
    [methodical.core :as m]
+   [next.jdbc]
+   [next.jdbc.prepare :as next.jdbc.prepare]
    [toucan2.jdbc.options :as jdbc.options]
    [toucan2.jdbc.read :as jdbc.read]
    [toucan2.jdbc.result-set :as jdbc.rs]
    [toucan2.log :as log]
    [toucan2.model :as model]
    [toucan2.pipeline :as pipeline]
+   [toucan2.realize :as realize]
    [toucan2.util :as u])
   (:import
-   (java.sql ResultSet ResultSetMetaData Types)))
+   (java.sql PreparedStatement ResultSet ResultSetMetaData Types)))
 
 (set! *warn-on-reflection* true)
 
@@ -41,25 +44,78 @@
                   [::connection :default Types/TIMESTAMP]
                   [java.sql.Connection :default Types/TIMESTAMP])
 
-;;;; INSERT RETURN_GENERATED_KEYS with explicit non-integer PK value workaround
+;;;; INSERT RETURN_GENERATED_KEYS workarounds
+
+(defn- single-row-sql-args
+  "Compile a single-row version of the current INSERT for each row in `rows`, using the same build/compile pipeline the
+  original multi-row query went through."
+  [query-type model rows]
+  (mapv (fn [row]
+          (pipeline/compile query-type model
+                            (pipeline/build query-type model
+                                            (assoc pipeline/*parsed-args* :rows [row])
+                                            pipeline/*resolved-query*)))
+        rows))
+
+(defn- normalize-generated-key
+  "Bring integral generated keys back to `Long`.
+
+  Nothing server-side is new here: the MySQL wire protocol has always reported `last_insert_id` as an unsigned
+  64-bit integer. What changed in mariadb-java-client 3.x is how the driver types the synthetic `getGeneratedKeys`
+  result set it builds from that value: 2.x declared the column a (signed) BIGINT and returned `Long`; 3.x declares
+  it `BIGINT UNSIGNED` — faithful to the protocol, since the value could in principle exceed `Long/MAX_VALUE` — and
+  the driver's type mapping for unsigned BIGINT is `java.math.BigInteger`. Downstream code dispatches on PK class —
+  e.g. `(select model pk)` builds a PK query for `Long` but passes a `BigInteger` through as if it were a compiled
+  query — so coerce keys back to `Long` (`.longValueExact` throws rather than truncates in the fanciful case of a
+  key beyond `Long/MAX_VALUE`)."
+  [v]
+  (cond
+    (instance? java.math.BigInteger v) (.longValueExact ^java.math.BigInteger v)
+    (vector? v)                        (mapv normalize-generated-key v)
+    :else                              v))
+
+(defn- execute-batched-inserts-returning-key-rows!
+  "Execute compiled single-row INSERT `sql-argses` as JDBC batches — one batch per consecutive run of identical SQL —
+  and return the generated-key rows in insertion order."
+  [conn model sql-argses]
+  (let [opts (jdbc.options/merge-options nil)]
+    (reduce (fn [acc sql-args-group]
+              (let [sql (ffirst sql-args-group)]
+                (with-open [ps (next.jdbc/prepare conn [sql] (assoc opts :return-keys true))]
+                  (doseq [sql-args sql-args-group]
+                    (next.jdbc.prepare/set-parameters ps (vec (rest sql-args)))
+                    (.addBatch ^PreparedStatement ps))
+                  (.executeBatch ^PreparedStatement ps)
+                  (with-open [rset (.getGeneratedKeys ^PreparedStatement ps)]
+                    ;; key rows are lazily backed by the live ResultSet -- realize them before it closes
+                    (jdbc.rs/reduce-result-set ((map realize/realize) conj) acc conn model rset opts)))))
+            []
+            (partition-by first sql-argses))))
 
 (m/defmethod pipeline/transduce-execute-with-connection [#_conn       ::connection
                                                          #_query-type :toucan.query-type/insert.pks
                                                          #_model      :default]
-  "Apparently `RETURN_GENERATED_KEYS` doesn't work for MySQL/MariaDB if:
+  "Two workarounds:
 
-  1. Values for the primary key are specified in the INSERT itself, *and*
-
-  2. The primary key is not an integer.
-
-  So to work around this we will look at the rows we're inserting: if every rows specifies the primary key
-  column(s) (including `nil` values), we'll transduce those specified values rather than what JDBC returns.
+  1. Apparently `RETURN_GENERATED_KEYS` doesn't work for MySQL/MariaDB if values for the primary key are specified in
+  the INSERT itself *and* the primary key is not an integer. So look at the rows we're inserting: if every row
+  specifies the primary key column(s) (including `nil` values), transduce those specified values rather than what JDBC
+  returns.
 
   This seems like it won't work if these values were arbitrary Honey SQL expressions. I suppose we could work around
-  THAT problem by running the primary key values thru another SELECT query... but that just seems like too much. I guess
-  we can cross that bridge when we get there."
+  THAT problem by running the primary key values thru another SELECT query... but that just seems like too much. I
+  guess we can cross that bridge when we get there.
+
+  2. The server only reports the FIRST generated key for a multi-row `INSERT ... VALUES (...), (...)`. The 2.x MariaDB
+  connector fabricated the remaining keys arithmetically from `auto_increment_increment` — plausible on a single-node
+  server, silently wrong on Galera/multi-master (where the increment changes with cluster topology) and for mixed
+  explicit-PK inserts — and the 3.x connector stopped guessing and returns only the first key. Executing the same
+  insert as a JDBC *batch* of single-row statements sidesteps all of that: the driver reports each statement's own
+  server-reported key. So multi-row inserts are recompiled per row and executed as a batch."
   [rf conn query-type model compiled-query]
-  (let [rows                 (:rows pipeline/*parsed-args*)
+  ;; rows can come from the parsed args or from the resolved query (e.g. named queries) -- same lookup the
+  ;; Honey SQL build method does
+  (let [rows                 (some (comp not-empty :rows) [pipeline/*parsed-args* pipeline/*resolved-query*])
         pks                  (model/primary-keys model)
         return-pks-directly? (and (seq rows)
                                   (every? (fn [row]
@@ -67,7 +123,8 @@
                                                       (contains? row k))
                                                     pks))
                                           rows))]
-    (if return-pks-directly?
+    (cond
+      return-pks-directly?
       (do
         (pipeline/transduce-execute-with-connection (pipeline/default-rf :toucan.query-type/insert.update-count)
                                                     conn
@@ -78,7 +135,22 @@
          (map (model/select-pks-fn model))
          rf
          rows))
-      (next-method rf conn query-type model compiled-query))))
+
+      ;; multi-row insert relying on generated keys: recompile per row and execute as a batch (see workaround 2 above)
+      (next rows)
+      (let [key-rows (execute-batched-inserts-returning-key-rows!
+                      conn
+                      model
+                      (single-row-sql-args query-type model rows))]
+        (log/debugf "batched multi-row insert workaround: got %s generated key rows" (count key-rows))
+        (transduce
+         (comp (map (model/select-pks-fn model))
+               (map normalize-generated-key))
+         rf
+         key-rows))
+
+      :else
+      (next-method ((map normalize-generated-key) rf) conn query-type model compiled-query))))
 
 (m/prefer-method! #'pipeline/transduce-execute-with-connection
                   [::connection :toucan.query-type/insert.pks :default]

--- a/test/toucan2/insert_test.clj
+++ b/test/toucan2/insert_test.clj
@@ -178,6 +178,25 @@
                                                      :updated-at (LocalDateTime/parse "2017-01-01T00:00")})]
                   (select/select ::test/venues :id [:>= 4] {:order-by [[:id :asc]]})))))))))
 
+(deftest ^:synchronized multiple-rows-generated-keys-test
+  (testing (str "Every row's real PK comes back for a multi-row insert, in row order. The MySQL wire protocol only "
+                "reports the FIRST generated key for a multi-row INSERT; mariadb-java-client 2.x fabricated the rest "
+                "arithmetically (silently wrong on Galera) and 3.x returns only the first, so the MySQL/MariaDB "
+                "backend executes multi-row inserts returning PKs as a JDBC batch. See [[toucan2.jdbc.mysql-mariadb]].")
+    (let [rows [{:name "Multi Row 1", :category "bar"}
+                {:name "Multi Row 2", :category "bar"}
+                {:name "Multi Row 3", :category "bar"}]]
+      (test/with-discarded-table-changes :venues
+        (let [pks (insert/insert-returning-pks! ::test/venues rows)]
+          (is (= (count rows)
+                 (count pks)))
+          (testing "each returned PK belongs to the corresponding inserted row"
+            (is (= (map :name rows)
+                   (map #(select/select-one-fn :name ::test/venues %) pks))))))
+      (test/with-discarded-table-changes :venues
+        (is (= (map :name rows)
+               (map :name (insert/insert-returning-instances! ::test/venues rows))))))))
+
 (deftest ^:synchronized key-values-test
   (do-insert-and-insert-returning-pks
    (fn [returning-keys? insert!]

--- a/test/toucan2/test.clj
+++ b/test/toucan2/test.clj
@@ -187,7 +187,8 @@
 
 (defmethod default-test-db-url :mariadb
   [_db-type]
-  "jdbc:mysql://localhost:3306/metabase_test?user=root")
+  ;; mariadb-java-client 3.x only claims `jdbc:mysql:` URLs when the URL string contains `permitMysqlScheme`
+  "jdbc:mysql://localhost:3306/metabase_test?user=root&permitMysqlScheme=true")
 
 (defmethod default-test-db-url :h2
   [_db-type]


### PR DESCRIPTION
Two behavior changes in the mariadb-java-client 3.x connector break `insert-returning-pks!`/`-instances!` (and the Toucan 1 compat `insert-many!`) on MySQL/MariaDB. Context: MySQL's move to calendar versioning (26.7.0 is current `mysql:latest`) forces the 2.x → 3.x driver upgrade downstream — 2.x decides "is this MariaDB?" by `version >= 10.1.2`, so it now sends MariaDB-only `SET STATEMENT max_statement_time` syntax to MySQL 26 and fails every statement carrying a query timeout. There is no fixed 2.x release; the pin this repo has carried (2.7.8, whose comment deferred exactly this problem) stops being viable.

### 1. Multi-row inserts: only the first generated key comes back

The MySQL wire protocol only reports the **first** generated key for a multi-row `INSERT ... VALUES (...), (...)`. The 2.x driver fabricated the rest arithmetically from `auto_increment_increment` — plausible on a single-node server, silently wrong on Galera/multi-master (the increment tracks cluster topology via `wsrep_auto_increment_control`) and for mixed explicit-PK inserts. 3.x stopped guessing and returns just the first key, which truncates `insert-returning-pks!` results.

**Fix**: execute multi-row inserts returning PKs as a JDBC *batch* of single-row statements — the driver reports each statement's own server-reported key, correctly on both 2.x and 3.x, including on Galera where the 2.x arithmetic never was correct. The insert.pks workaround recompiles the insert per row through the normal build/compile pipeline (so model/query customizations are honored), executes one batch per consecutive run of identical SQL, realizes generated-key rows while their `ResultSet` is open, and finds rows the same way the Honey SQL build method does (parsed args or resolved query, so named queries work).

### 2. Generated keys changed class: `Long` → `java.math.BigInteger`

Nothing server-side changed — the wire protocol has always reported `last_insert_id` as an unsigned 64-bit integer. What changed is how the driver types the synthetic `getGeneratedKeys` result set: 2.x declared the column signed `BIGINT` → `Long`; 3.x declares it `BIGINT UNSIGNED` (faithful to the protocol) → `BigInteger`. Downstream code dispatches on PK class — `(select model pk)` builds a PK query for `Long` but passes a `BigInteger` through `build`'s `:default` (identity) as if it were an already-compiled query, and the first consumer that treats it as `[sql & args]` throws `Don't know how to create ISeq from: java.math.BigInteger`. And since the `id` column itself is signed `BIGINT`, SELECTs return `Long` — letting the `BigInteger` through would give the same id two classes depending on how you obtained it.

**Fix**: normalize integral generated keys back to `Long` on both the batch and single-statement paths (`.longValueExact`, so a key genuinely beyond `Long/MAX_VALUE` throws rather than truncates).

### Also

- Test dependency bumped 2.7.8 → 3.5.9 (the old pin is what kept both issues invisible to CI) and `permitMysqlScheme` added to the default `jdbc:mysql:` test URL — 3.x only claims that scheme when the URL string contains the flag.
- New `multiple-rows-generated-keys-test` pins the behavior property-wise (count + per-row correspondence via re-select, no hardcoded ids).

### Validation

Full suite (407 tests, including the Toucan 1 compat tests — `toucan.db-test/insert-many!-test` was among the failures before the fix) against MariaDB 12.3 on **both** 3.5.9 (new default) and 2.7.8 (override), plus H2. Downstream, Metabase's full MySQL/MariaDB CI matrix is being run against this commit via a git dep on metabase#78808 (the driver-bump PR this unblocks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019oNinGgrbARmQYynfE9KD4